### PR TITLE
Feature: ROS_DOMAIN_ID support

### DIFF
--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -76,12 +76,13 @@ enum ESensors {
 
 void ROS2::Enable(bool enable) {
   _enabled = enable;
+  ObtainDomainId();
   log_info("ROS2 enabled: ", _enabled);
   _clock_publisher = std::make_shared<CarlaClockPublisher>("clock", "");
-  _clock_publisher->Init();
+  _clock_publisher->Init(_domain_id);
 #if defined(WITH_ROS2_DEMO)
   _basic_publisher = std::make_shared<BasicPublisher>("basic_publisher", "");
-  _basic_publisher->Init();
+  _basic_publisher->Init(_domain_id);
 #endif
 }
 
@@ -230,6 +231,27 @@ void ROS2::RemoveActorCallback(void* actor) {
   _actor_callbacks.erase(actor);
 }
 
+bool ROS2::ObtainDomainId() {
+  const auto domain_id = std::getenv("ROS_DOMAIN_ID");
+  if (domain_id == nullptr) {
+    return false;
+  }
+
+  int new_domain_id;
+  try {
+    new_domain_id = std::stoi(std::string{domain_id});
+  } catch (...) {
+    return false;
+  }
+
+  if (new_domain_id < 0) {
+    return false;
+  }
+
+  _domain_id = new_domain_id;
+  return true;
+}
+
 std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublisher>> ROS2::GetOrCreateSensor(int type, carla::streaming::detail::stream_id_type id, void* actor) {
   auto it_publishers = _publishers.find(actor);
   auto it_transforms = _transforms.find(actor);
@@ -254,12 +276,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaCollisionPublisher> new_publisher = std::make_shared<CarlaCollisionPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -272,12 +294,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaDepthCameraPublisher> new_publisher = std::make_shared<CarlaDepthCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -290,12 +312,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaNormalsCameraPublisher> new_publisher = std::make_shared<CarlaNormalsCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -308,12 +330,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaDVSCameraPublisher> new_publisher = std::make_shared<CarlaDVSCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -326,12 +348,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaGNSSPublisher> new_publisher = std::make_shared<CarlaGNSSPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -344,12 +366,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaIMUPublisher> new_publisher = std::make_shared<CarlaIMUPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -362,12 +384,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaLineInvasionPublisher> new_publisher = std::make_shared<CarlaLineInvasionPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -383,12 +405,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaOpticalFlowCameraPublisher> new_publisher = std::make_shared<CarlaOpticalFlowCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -401,12 +423,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaRadarPublisher> new_publisher = std::make_shared<CarlaRadarPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -419,12 +441,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaSemanticLidarPublisher> new_publisher = std::make_shared<CarlaSemanticLidarPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -437,12 +459,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaLidarPublisher> new_publisher = std::make_shared<CarlaLidarPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -458,12 +480,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaRGBCameraPublisher> new_publisher = std::make_shared<CarlaRGBCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -476,12 +498,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaSSCameraPublisher> new_publisher = std::make_shared<CarlaSSCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }
@@ -494,12 +516,12 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           UpdateActorRosName(actor, ros_name);
         }
         std::shared_ptr<CarlaISCameraPublisher> new_publisher = std::make_shared<CarlaISCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_publisher->Init()) {
+        if (new_publisher->Init(_domain_id)) {
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
         std::shared_ptr<CarlaTransformPublisher> new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
-        if (new_transform->Init()) {
+        if (new_transform->Init(_domain_id)) {
           _transforms.insert({actor, new_transform});
           transform = new_transform;
         }

--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -207,7 +207,7 @@ void ROS2::AddBasicSubscriberCallback(void* actor, std::string ros_name, ActorMe
 
   _basic_subscriber.reset();
   _basic_subscriber = std::make_shared<BasicSubscriber>(actor, ros_name.c_str());
-  _basic_subscriber->Init();
+  _basic_subscriber->Init(_domain_id);
   #endif
 }
 
@@ -223,7 +223,7 @@ void ROS2::AddActorCallback(void* actor, std::string ros_name, ActorCallback cal
 
   _controller.reset();
   _controller = std::make_shared<CarlaEgoVehicleControlSubscriber>(actor, ros_name.c_str());
-  _controller->Init();
+  _controller->Init(_domain_id);
 }
 
 void ROS2::RemoveActorCallback(void* actor) {

--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -4,6 +4,7 @@
 // This work is licensed under the terms of the MIT license.
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
+#include <charconv>
 #include "carla/Logging.h"
 #include "carla/ros2/ROS2.h"
 #include "carla/geom/GeoLocation.h"
@@ -231,21 +232,25 @@ void ROS2::RemoveActorCallback(void* actor) {
   _actor_callbacks.erase(actor);
 }
 
-bool ROS2::ObtainDomainId() {
-  const auto domain_id = std::getenv("ROS_DOMAIN_ID");
-  if (domain_id == nullptr) {
-    return false;
+bool ROS2::ObtainDomainId() noexcept
+{
+  const char* domain_id = std::getenv("ROS_DOMAIN_ID");
+  if (!domain_id) {
+    return false; // environment variable not set
   }
 
-  int new_domain_id;
-  try {
-    new_domain_id = std::stoi(std::string{domain_id});
-  } catch (...) {
-    return false;
+  int new_domain_id{};
+  const char* end = domain_id + std::strlen(domain_id);
+
+  // parse directly with from_chars
+  auto [ptr, ec] = std::from_chars(domain_id, end, new_domain_id);
+
+  if (ec != std::errc{} || ptr != end) {
+    return false; // parse error, overflow, or leftover garbage
   }
 
   if (new_domain_id < 0) {
-    return false;
+    return false; // negative IDs are invalid
   }
 
   _domain_id = new_domain_id;

--- a/LibCarla/source/carla/ros2/ROS2.h
+++ b/LibCarla/source/carla/ros2/ROS2.h
@@ -151,12 +151,15 @@ void ProcessDataFromCollisionSensor(
   // sigleton
   ROS2() {};
 
+  bool ObtainDomainId();
+
   static std::shared_ptr<ROS2> _instance;
 
   bool _enabled { false };
   uint64_t _frame { 0 };
   int32_t _seconds { 0 };
   uint32_t _nanoseconds { 0 };
+  uint32_t _domain_id { 0U };
   std::unordered_map<void *, std::string> _actor_ros_name;
   std::unordered_map<void *, std::vector<void*> > _actor_parent_ros_name;
   std::shared_ptr<CarlaEgoVehicleControlSubscriber> _controller;

--- a/LibCarla/source/carla/ros2/ROS2.h
+++ b/LibCarla/source/carla/ros2/ROS2.h
@@ -145,13 +145,15 @@ void ProcessDataFromCollisionSensor(
     carla::geom::Vector3D impulse,
     void* actor);
 
+    uint32_t GetDomainId() const noexcept { return _domain_id; }
+
   private:
   std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublisher>> GetOrCreateSensor(int type, carla::streaming::detail::stream_id_type id, void* actor);
 
   // sigleton
   ROS2() {};
 
-  bool ObtainDomainId();
+  bool ObtainDomainId() noexcept;
 
   static std::shared_ptr<ROS2> _instance;
 

--- a/LibCarla/source/carla/ros2/publishers/BasicPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/BasicPublisher.cpp
@@ -38,7 +38,7 @@ namespace ros2 {
     std_msgs::msg::String _message {};
   };
 
-  bool BasicPublisher::Init() {
+  bool BasicPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -46,7 +46,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/BasicPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/BasicPublisher.h
@@ -21,7 +21,7 @@ namespace ros2 {
       BasicPublisher(BasicPublisher&&);
       BasicPublisher& operator=(BasicPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(const char* msg);
       const char* type() const override { return "basic_publisher"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaClockPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaClockPublisher.cpp
@@ -37,7 +37,7 @@ namespace ros2 {
     rosgraph::msg::Clock _clock {};
   };
 
-  bool CarlaClockPublisher::Init() {
+  bool CarlaClockPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -45,7 +45,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaClockPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaClockPublisher.h
@@ -23,7 +23,7 @@ namespace ros2 {
       CarlaClockPublisher(CarlaClockPublisher&&);
       CarlaClockPublisher& operator=(CarlaClockPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t sec, uint32_t nanosec);
       const char* type() const override { return "clock"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaCollisionPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaCollisionPublisher.cpp
@@ -38,7 +38,7 @@ namespace ros2 {
     carla_msgs::msg::CarlaCollisionEvent _event {};
   };
 
-  bool CarlaCollisionPublisher::Init() {
+  bool CarlaCollisionPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -47,7 +47,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaCollisionPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaCollisionPublisher.h
@@ -23,7 +23,7 @@ namespace ros2 {
       CarlaCollisionPublisher(CarlaCollisionPublisher&&);
       CarlaCollisionPublisher& operator=(CarlaCollisionPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, uint32_t actor_id, float x, float y, float z);
       const char* type() const override { return "collision"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
@@ -74,7 +74,7 @@ namespace ros2 {
   }
 
   bool CarlaDVSCameraPublisher::Init(const DomainId domain_id) {
-    return InitImage(domain_id) && InitInfo() && InitPointCloud();
+    return InitImage(domain_id) && InitInfo(domain_id) && InitPointCloud(domain_id);
   }
 
   bool CarlaDVSCameraPublisher::InitImage(const DomainId domain_id) {
@@ -126,7 +126,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaDVSCameraPublisher::InitInfo() {
+  bool CarlaDVSCameraPublisher::InitInfo(const DomainId domain_id) {
     if (_info->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -135,7 +135,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _info->_participant = factory->create_participant(0, pqos);
+    _info->_participant = factory->create_participant(domain_id, pqos);
     if (_info->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;
@@ -174,7 +174,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaDVSCameraPublisher::InitPointCloud() {
+  bool CarlaDVSCameraPublisher::InitPointCloud(const DomainId domain_id) {
     if (_point_cloud->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -183,7 +183,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _point_cloud->_participant = factory->create_participant(0, pqos);
+    _point_cloud->_participant = factory->create_participant(domain_id, pqos);
     if (_point_cloud->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
@@ -73,11 +73,11 @@ namespace ros2 {
     _info->_init = true;
   }
 
-  bool CarlaDVSCameraPublisher::Init() {
-    return InitImage() && InitInfo() && InitPointCloud();
+  bool CarlaDVSCameraPublisher::Init(const DomainId domain_id) {
+    return InitImage(domain_id) && InitInfo() && InitPointCloud();
   }
 
-  bool CarlaDVSCameraPublisher::InitImage() {
+  bool CarlaDVSCameraPublisher::InitImage(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -86,7 +86,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.h
@@ -25,7 +25,7 @@ namespace ros2 {
       CarlaDVSCameraPublisher(CarlaDVSCameraPublisher&&);
       CarlaDVSCameraPublisher& operator=(CarlaDVSCameraPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       void InitInfoData(uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, float fov, bool do_rectify);
       bool Publish();
 
@@ -37,7 +37,7 @@ namespace ros2 {
 
     private:
     private:
-      bool InitImage();
+      bool InitImage(const DomainId domain_id);
       bool InitInfo();
       bool InitPointCloud();
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.h
@@ -38,8 +38,8 @@ namespace ros2 {
     private:
     private:
       bool InitImage(const DomainId domain_id);
-      bool InitInfo();
-      bool InitPointCloud();
+      bool InitInfo(const DomainId domain_id);
+      bool InitPointCloud(const DomainId domain_id);
 
       void SetInfoRegionOfInterest( uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, bool do_rectify);
       void SetData(int32_t seconds, uint32_t nanoseconds, size_t height, size_t width, std::vector<uint8_t>&& data);

--- a/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.cpp
@@ -60,11 +60,11 @@ namespace ros2 {
     _impl_info->_init = true;
   }
 
-  bool CarlaDepthCameraPublisher::Init() {
-    return InitImage() && InitInfo();
+  bool CarlaDepthCameraPublisher::Init(const DomainId domain_id) {
+    return InitImage(domain_id) && InitInfo();
   }
 
-  bool CarlaDepthCameraPublisher::InitImage() {
+  bool CarlaDepthCameraPublisher::InitImage(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -73,7 +73,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.cpp
@@ -61,7 +61,7 @@ namespace ros2 {
   }
 
   bool CarlaDepthCameraPublisher::Init(const DomainId domain_id) {
-    return InitImage(domain_id) && InitInfo();
+    return InitImage(domain_id) && InitInfo(domain_id);
   }
 
   bool CarlaDepthCameraPublisher::InitImage(const DomainId domain_id) {
@@ -113,7 +113,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaDepthCameraPublisher::InitInfo() {
+  bool CarlaDepthCameraPublisher::InitInfo(const DomainId domain_id) {
     if (_impl_info->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -122,7 +122,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl_info->_participant = factory->create_participant(0, pqos);
+    _impl_info->_participant = factory->create_participant(domain_id, pqos);
     if (_impl_info->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.h
@@ -24,7 +24,7 @@ namespace ros2 {
       CarlaDepthCameraPublisher(CarlaDepthCameraPublisher&&);
       CarlaDepthCameraPublisher& operator=(CarlaDepthCameraPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       void InitInfoData(uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, float fov, bool do_rectify);
       bool Publish();
 
@@ -34,7 +34,7 @@ namespace ros2 {
       const char* type() const override { return "depth camera"; }
 
     private:
-      bool InitImage();
+      bool InitImage(const DomainId domain_id);
       bool InitInfo();
       bool PublishImage();
       bool PublishInfo();

--- a/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDepthCameraPublisher.h
@@ -35,7 +35,7 @@ namespace ros2 {
 
     private:
       bool InitImage(const DomainId domain_id);
-      bool InitInfo();
+      bool InitInfo(const DomainId domain_id);
       bool PublishImage();
       bool PublishInfo();
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaGNSSPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaGNSSPublisher.cpp
@@ -37,7 +37,7 @@ namespace ros2 {
     sensor_msgs::msg::NavSatFix _nav {};
   };
 
-  bool CarlaGNSSPublisher::Init() {
+  bool CarlaGNSSPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -46,7 +46,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaGNSSPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaGNSSPublisher.h
@@ -22,7 +22,7 @@ namespace ros2 {
       CarlaGNSSPublisher(CarlaGNSSPublisher&&);
       CarlaGNSSPublisher& operator=(CarlaGNSSPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, const double* data);
       const char* type() const override { return "gnss"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.cpp
@@ -37,7 +37,7 @@ namespace ros2 {
     sensor_msgs::msg::Imu _imu {};
   };
 
-  bool CarlaIMUPublisher::Init() {
+  bool CarlaIMUPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -46,7 +46,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.h
@@ -22,7 +22,7 @@ namespace ros2 {
       CarlaIMUPublisher(CarlaIMUPublisher&&);
       CarlaIMUPublisher& operator=(CarlaIMUPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, float* accelerometer, float* gyroscope, float compass);
       const char* type() const override { return "inertial measurement unit"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.cpp
@@ -59,11 +59,11 @@ namespace ros2 {
     _impl_info->_init = true;
   }
 
-  bool CarlaISCameraPublisher::Init() {
-    return InitImage() && InitInfo();
+  bool CarlaISCameraPublisher::Init(const DomainId domain_id) {
+    return InitImage(domain_id) && InitInfo();
   }
 
-  bool CarlaISCameraPublisher::InitImage() {
+  bool CarlaISCameraPublisher::InitImage(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -71,7 +71,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.cpp
@@ -60,7 +60,7 @@ namespace ros2 {
   }
 
   bool CarlaISCameraPublisher::Init(const DomainId domain_id) {
-    return InitImage(domain_id) && InitInfo();
+    return InitImage(domain_id) && InitInfo(domain_id);
   }
 
   bool CarlaISCameraPublisher::InitImage(const DomainId domain_id) {
@@ -111,7 +111,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaISCameraPublisher::InitInfo() {
+  bool CarlaISCameraPublisher::InitInfo(const DomainId domain_id) {
     if (_impl_info->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -120,7 +120,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl_info->_participant = factory->create_participant(0, pqos);
+    _impl_info->_participant = factory->create_participant(domain_id, pqos);
     if (_impl_info->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.h
@@ -24,7 +24,7 @@ namespace ros2 {
       CarlaISCameraPublisher(CarlaISCameraPublisher&&);
       CarlaISCameraPublisher& operator=(CarlaISCameraPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       void InitInfoData(uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, float fov, bool do_rectify);
       bool Publish();
 
@@ -34,7 +34,7 @@ namespace ros2 {
       const char* type() const override { return "instance segmentation"; }
 
     private:
-      bool InitImage();
+      bool InitImage(const DomainId domain_id);
       bool InitInfo();
       bool PublishImage();
       bool PublishInfo();

--- a/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaISCameraPublisher.h
@@ -35,7 +35,7 @@ namespace ros2 {
 
     private:
       bool InitImage(const DomainId domain_id);
-      bool InitInfo();
+      bool InitInfo(const DomainId domain_id);
       bool PublishImage();
       bool PublishInfo();
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.cpp
@@ -37,7 +37,7 @@ namespace ros2 {
     sensor_msgs::msg::PointCloud2 _lidar {};
   };
 
-  bool CarlaLidarPublisher::Init() {
+  bool CarlaLidarPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -46,7 +46,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaLidarPublisher.h
@@ -23,7 +23,7 @@ namespace ros2 {
       CarlaLidarPublisher(CarlaLidarPublisher&&);
       CarlaLidarPublisher& operator=(CarlaLidarPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, size_t height, size_t width, float* data);
       const char* type() const override { return "lidar"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaLineInvasionPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaLineInvasionPublisher.cpp
@@ -37,7 +37,7 @@ namespace ros2 {
     carla_msgs::msg::LaneInvasionEvent _event {};
   };
 
-  bool CarlaLineInvasionPublisher::Init() {
+  bool CarlaLineInvasionPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -46,7 +46,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaLineInvasionPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaLineInvasionPublisher.h
@@ -22,7 +22,7 @@ namespace ros2 {
       CarlaLineInvasionPublisher(CarlaLineInvasionPublisher&&);
       CarlaLineInvasionPublisher& operator=(CarlaLineInvasionPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, const int32_t* data);
       const char* type() const override { return "line invasion"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaMapSensorPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaMapSensorPublisher.cpp
@@ -37,7 +37,7 @@ namespace ros2 {
     std_msgs::msg::String _string {};
   };
 
-  bool CarlaMapSensorPublisher::Init() {
+  bool CarlaMapSensorPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -46,7 +46,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaMapSensorPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaMapSensorPublisher.h
@@ -22,7 +22,7 @@ namespace ros2 {
       CarlaMapSensorPublisher(CarlaMapSensorPublisher&&);
       CarlaMapSensorPublisher& operator=(CarlaMapSensorPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(const char* data);
       const char* type() const override { return "map sensor"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.cpp
@@ -61,7 +61,7 @@ namespace ros2 {
   }
 
   bool CarlaNormalsCameraPublisher::Init(const DomainId domain_id) {
-    return InitImage(domain_id) && InitInfo();
+    return InitImage(domain_id) && InitInfo(domain_id);
   }
 
   bool CarlaNormalsCameraPublisher::InitImage(const DomainId domain_id) {
@@ -113,7 +113,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaNormalsCameraPublisher::InitInfo() {
+  bool CarlaNormalsCameraPublisher::InitInfo(const DomainId domain_id) {
     if (_impl_info->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -122,7 +122,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl_info->_participant = factory->create_participant(0, pqos);
+    _impl_info->_participant = factory->create_participant(domain_id, pqos);
     if (_impl_info->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.cpp
@@ -60,11 +60,11 @@ namespace ros2 {
     _impl_info->_init = true;
   }
 
-  bool CarlaNormalsCameraPublisher::Init() {
-    return InitImage() && InitInfo();
+  bool CarlaNormalsCameraPublisher::Init(const DomainId domain_id) {
+    return InitImage(domain_id) && InitInfo();
   }
 
-  bool CarlaNormalsCameraPublisher::InitImage() {
+  bool CarlaNormalsCameraPublisher::InitImage(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -73,7 +73,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.h
@@ -24,7 +24,7 @@ namespace ros2 {
       CarlaNormalsCameraPublisher(CarlaNormalsCameraPublisher&&);
       CarlaNormalsCameraPublisher& operator=(CarlaNormalsCameraPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       void InitInfoData(uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, float fov, bool do_rectify);
       bool Publish();
 
@@ -35,7 +35,7 @@ namespace ros2 {
       const char* type() const override { return "normals camera"; }
 
     private:
-      bool InitImage();
+      bool InitImage(const DomainId domain_id);
       bool InitInfo();
       bool PublishImage();
       bool PublishInfo();

--- a/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaNormalsCameraPublisher.h
@@ -36,7 +36,7 @@ namespace ros2 {
 
     private:
       bool InitImage(const DomainId domain_id);
-      bool InitInfo();
+      bool InitInfo(const DomainId domain_id);
       bool PublishImage();
       bool PublishInfo();
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.cpp
@@ -64,11 +64,11 @@ namespace ros2 {
     _impl_info->_init = true;
   }
 
-  bool CarlaOpticalFlowCameraPublisher::Init() {
-    return InitImage() && InitInfo();
+  bool CarlaOpticalFlowCameraPublisher::Init(const DomainId domain_id) {
+    return InitImage(domain_id) && InitInfo();
   }
 
-  bool CarlaOpticalFlowCameraPublisher::InitImage() {
+  bool CarlaOpticalFlowCameraPublisher::InitImage(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -77,7 +77,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.cpp
@@ -65,7 +65,7 @@ namespace ros2 {
   }
 
   bool CarlaOpticalFlowCameraPublisher::Init(const DomainId domain_id) {
-    return InitImage(domain_id) && InitInfo();
+    return InitImage(domain_id) && InitInfo(domain_id);
   }
 
   bool CarlaOpticalFlowCameraPublisher::InitImage(const DomainId domain_id) {
@@ -117,7 +117,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaOpticalFlowCameraPublisher::InitInfo() {
+  bool CarlaOpticalFlowCameraPublisher::InitInfo(const DomainId domain_id) {
     if (_impl_info->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -126,7 +126,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl_info->_participant = factory->create_participant(0, pqos);
+    _impl_info->_participant = factory->create_participant(domain_id, pqos);
     if (_impl_info->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.h
@@ -24,7 +24,7 @@ namespace ros2 {
       CarlaOpticalFlowCameraPublisher(CarlaOpticalFlowCameraPublisher&&);
       CarlaOpticalFlowCameraPublisher& operator=(CarlaOpticalFlowCameraPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       void InitInfoData(uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, float fov, bool do_rectify);
       bool Publish();
 
@@ -34,7 +34,7 @@ namespace ros2 {
       const char* type() const override { return "optical flow camera"; }
 
     private:
-      bool InitImage();
+      bool InitImage(const DomainId domain_id);
       bool InitInfo();
       bool PublishImage();
       bool PublishInfo();

--- a/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaOpticalFlowCameraPublisher.h
@@ -35,7 +35,7 @@ namespace ros2 {
 
     private:
       bool InitImage(const DomainId domain_id);
-      bool InitInfo();
+      bool InitInfo(const DomainId domain_id);
       bool PublishImage();
       bool PublishInfo();
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaPublisher.h
@@ -11,6 +11,8 @@ namespace ros2 {
 
   class CarlaPublisher {
     public:
+      using DomainId = uint32_t;
+
       const std::string& frame_id() const { return _frame_id; }
       const std::string& name() const { return _name; }
       const std::string& parent() const { return _parent; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.cpp
@@ -61,7 +61,7 @@ namespace ros2 {
   }
 
   bool CarlaRGBCameraPublisher::Init(const DomainId domain_id) {
-    return InitImage(domain_id) && InitInfo();
+    return InitImage(domain_id) && InitInfo(domain_id);
   }
 
   bool CarlaRGBCameraPublisher::InitImage(const DomainId domain_id) {
@@ -113,7 +113,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaRGBCameraPublisher::InitInfo() {
+  bool CarlaRGBCameraPublisher::InitInfo(const DomainId domain_id) {
     if (_impl_info->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -122,7 +122,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl_info->_participant = factory->create_participant(0, pqos);
+    _impl_info->_participant = factory->create_participant(domain_id, pqos);
     if (_impl_info->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.cpp
@@ -60,11 +60,11 @@ namespace ros2 {
     _impl_info->_init = true;
   }
 
-  bool CarlaRGBCameraPublisher::Init() {
-    return InitImage() && InitInfo();
+  bool CarlaRGBCameraPublisher::Init(const DomainId domain_id) {
+    return InitImage(domain_id) && InitInfo();
   }
 
-  bool CarlaRGBCameraPublisher::InitImage() {
+  bool CarlaRGBCameraPublisher::InitImage(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -73,7 +73,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.h
@@ -24,7 +24,7 @@ namespace ros2 {
       CarlaRGBCameraPublisher(CarlaRGBCameraPublisher&&);
       CarlaRGBCameraPublisher& operator=(CarlaRGBCameraPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       void InitInfoData(uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, float fov, bool do_rectify);
       bool Publish();
 
@@ -34,7 +34,7 @@ namespace ros2 {
       const char* type() const override { return "rgb camera"; }
 
     private:
-      bool InitImage();
+      bool InitImage(const DomainId domain_id);
       bool InitInfo();
       bool PublishImage();
       bool PublishInfo();

--- a/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRGBCameraPublisher.h
@@ -35,7 +35,7 @@ namespace ros2 {
 
     private:
       bool InitImage(const DomainId domain_id);
-      bool InitInfo();
+      bool InitInfo(const DomainId domain_id);
       bool PublishImage();
       bool PublishInfo();
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.cpp
@@ -46,7 +46,7 @@ namespace ros2 {
     carla::sensor::data::RadarDetection detection;
   };
 
-  bool CarlaRadarPublisher::Init() {
+  bool CarlaRadarPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -55,7 +55,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaRadarPublisher.h
@@ -23,7 +23,7 @@ namespace ros2 {
       CarlaRadarPublisher(CarlaRadarPublisher&&);
       CarlaRadarPublisher& operator=(CarlaRadarPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, size_t height, size_t width, size_t elements, const uint8_t* data);
       const char* type() const override { return "radar"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.cpp
@@ -59,11 +59,11 @@ namespace ros2 {
     _impl_info->_init = true;
   }
 
-  bool CarlaSSCameraPublisher::Init() {
-    return InitImage() && InitInfo();
+  bool CarlaSSCameraPublisher::Init(const DomainId domain_id) {
+    return InitImage(domain_id) && InitInfo();
   }
 
-  bool CarlaSSCameraPublisher::InitImage() {
+  bool CarlaSSCameraPublisher::InitImage(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -71,7 +71,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.cpp
@@ -60,7 +60,7 @@ namespace ros2 {
   }
 
   bool CarlaSSCameraPublisher::Init(const DomainId domain_id) {
-    return InitImage(domain_id) && InitInfo();
+    return InitImage(domain_id) && InitInfo(domain_id);
   }
 
   bool CarlaSSCameraPublisher::InitImage(const DomainId domain_id) {
@@ -111,7 +111,7 @@ namespace ros2 {
     return true;
   }
 
-  bool CarlaSSCameraPublisher::InitInfo() {
+  bool CarlaSSCameraPublisher::InitInfo(const DomainId domain_id) {
     if (_impl_info->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -120,7 +120,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl_info->_participant = factory->create_participant(0, pqos);
+    _impl_info->_participant = factory->create_participant(domain_id, pqos);
     if (_impl_info->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.h
@@ -24,7 +24,7 @@ namespace ros2 {
       CarlaSSCameraPublisher(CarlaSSCameraPublisher&&);
       CarlaSSCameraPublisher& operator=(CarlaSSCameraPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       void InitInfoData(uint32_t x_offset, uint32_t y_offset, uint32_t height, uint32_t width, float fov, bool do_rectify);
       bool Publish();
 
@@ -34,7 +34,7 @@ namespace ros2 {
       const char* type() const override { return "semantic segmentation"; }
 
     private:
-      bool InitImage();
+      bool InitImage(const DomainId domain_id);
       bool InitInfo();
       bool PublishImage();
       bool PublishInfo();

--- a/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSSCameraPublisher.h
@@ -35,7 +35,7 @@ namespace ros2 {
 
     private:
       bool InitImage(const DomainId domain_id);
-      bool InitInfo();
+      bool InitInfo(const DomainId domain_id);
       bool PublishImage();
       bool PublishInfo();
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.cpp
@@ -38,7 +38,7 @@ namespace ros2 {
     sensor_msgs::msg::PointCloud2 _lidar {};
   };
 
-  bool CarlaSemanticLidarPublisher::Init() {
+  bool CarlaSemanticLidarPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -46,7 +46,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSemanticLidarPublisher.h
@@ -23,7 +23,7 @@ namespace ros2 {
       CarlaSemanticLidarPublisher(CarlaSemanticLidarPublisher&&);
       CarlaSemanticLidarPublisher& operator=(CarlaSemanticLidarPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, size_t elements, size_t height, size_t width, float* data);
       const char* type() const override { return "semantic lidar"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaSpeedometerSensor.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSpeedometerSensor.cpp
@@ -37,7 +37,7 @@ namespace ros2 {
     std_msgs::msg::Float32 _float {};
   };
 
-  bool CarlaSpeedometerSensor::Init() {
+  bool CarlaSpeedometerSensor::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -45,7 +45,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaSpeedometerSensor.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaSpeedometerSensor.h
@@ -23,7 +23,7 @@ namespace ros2 {
       CarlaSpeedometerSensor(CarlaSpeedometerSensor&&);
       CarlaSpeedometerSensor& operator=(CarlaSpeedometerSensor&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(float data);
       const char* type() const override { return "speedometer"; }

--- a/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.cpp
@@ -42,7 +42,7 @@ namespace ros2 {
     geometry_msgs::msg::Quaternion vec_rotation;
   };
 
-  bool CarlaTransformPublisher::Init() {
+  bool CarlaTransformPublisher::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -51,7 +51,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/CarlaTransformPublisher.h
@@ -23,7 +23,7 @@ namespace ros2 {
       CarlaTransformPublisher(CarlaTransformPublisher&&);
       CarlaTransformPublisher& operator=(CarlaTransformPublisher&&);
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Publish();
       void SetData(int32_t seconds, uint32_t nanoseconds, const float* translation, const float* rotation);
       const char* type() const override { return "transform"; }

--- a/LibCarla/source/carla/ros2/subscribers/BasicSubscriber.cpp
+++ b/LibCarla/source/carla/ros2/subscribers/BasicSubscriber.cpp
@@ -42,7 +42,7 @@ namespace ros2 {
     void* _actor {nullptr};
   };
 
-  bool BasicSubscriber::Init() {
+  bool BasicSubscriber::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -51,7 +51,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/subscribers/BasicSubscriber.h
+++ b/LibCarla/source/carla/ros2/subscribers/BasicSubscriber.h
@@ -29,7 +29,7 @@ namespace ros2 {
       const char* GetMessage();
       void* GetActor();
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       // bool Read();
       const char* type() const override { return "basic_subscriber"; }
 

--- a/LibCarla/source/carla/ros2/subscribers/CarlaEgoVehicleControlSubscriber.cpp
+++ b/LibCarla/source/carla/ros2/subscribers/CarlaEgoVehicleControlSubscriber.cpp
@@ -42,7 +42,7 @@ namespace ros2 {
     void* _vehicle {nullptr};
   };
 
-  bool CarlaEgoVehicleControlSubscriber::Init() {
+  bool CarlaEgoVehicleControlSubscriber::Init(const DomainId domain_id) {
     if (_impl->_type == nullptr) {
         std::cerr << "Invalid TypeSupport" << std::endl;
         return false;
@@ -51,7 +51,7 @@ namespace ros2 {
     efd::DomainParticipantQos pqos = efd::PARTICIPANT_QOS_DEFAULT;
     pqos.name(_name);
     auto factory = efd::DomainParticipantFactory::get_instance();
-    _impl->_participant = factory->create_participant(0, pqos);
+    _impl->_participant = factory->create_participant(domain_id, pqos);
     if (_impl->_participant == nullptr) {
         std::cerr << "Failed to create DomainParticipant" << std::endl;
         return false;

--- a/LibCarla/source/carla/ros2/subscribers/CarlaEgoVehicleControlSubscriber.h
+++ b/LibCarla/source/carla/ros2/subscribers/CarlaEgoVehicleControlSubscriber.h
@@ -29,7 +29,7 @@ namespace ros2 {
       VehicleControl GetMessage();
       void* GetVehicle();
 
-      bool Init();
+      bool Init(const DomainId domain_id = 0U);
       bool Read();
       const char* type() const override { return "Ego vehicle control"; }
 

--- a/LibCarla/source/carla/ros2/subscribers/CarlaSubscriber.h
+++ b/LibCarla/source/carla/ros2/subscribers/CarlaSubscriber.h
@@ -11,6 +11,8 @@ namespace ros2 {
 
   class CarlaSubscriber {
     public:
+      using DomainId = uint32_t;
+
       const std::string& frame_id() const { return _frame_id; }
       const std::string& name() const { return _name; }
       const std::string& parent() const { return _parent; }


### PR DESCRIPTION
<!--

Thanks for sending a pull request! Please make sure you click the link above to
view the contribution guidelines, then fill out the blanks below.
Please, make sure if your contribution is for UE4 version of CARLA you merge against ue4-dev branch. 
if it is for UE5 version of CARLA you merge agaisnt ue5-dev branch

Checklist:

  - [ ] Your branch is up-to-date with the  `ue4-dev/ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [ ] Code compiles correctly
  - [ ] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes

-->

#### Description

<!-- Please explain the changes you made here as detailed as possible. -->

Adds manual support for `ROS_DOMAIN_ID` to mimic default ROS 2 behavior where env variable is taken into account to set the domain ID.

The domain ID is taken from env and used in all publishers and subscribers.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04
  * **Python version(s):** Python 3.10
  * **Unreal Engine version(s):** Unreal 5

#### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None

> [!NOTE]
> **For reviewers:** Please change target branch of #2 to `autoware-support` before merging this PR