### PR TITLE
Add a script to spawn a vehicle with a basic sensor setup

### DIFF
--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -1,0 +1,162 @@
+import carla
+import math
+import random
+import argparse
+
+def generate_vlp16_blueprint(blueprint_library):
+    """Generates a blueprint for VLP16
+
+    The following assumptions were made based on the configuration in AWSIM:
+    - 10 Hz publish frequency
+    - 0.2 deg horizontal resolution"""
+
+    blueprint = blueprint_library.find("sensor.lidar.ray_cast")
+
+    # The following values are taken from VLP16 datasheet
+    blueprint.set_attribute("channels", "16")
+    blueprint.set_attribute("range", "100.0")
+    blueprint.set_attribute("upper_fov", "10.0")
+    blueprint.set_attribute("lower_fov", "-20.0")
+
+    # Calculated as: horizontal_fov / horizontal_resolution / sensor_tick * channels
+    blueprint.set_attribute("points_per_second", "288000")
+
+    blueprint.set_attribute("sensor_tick", "0.1")
+
+    return blueprint
+
+def generate_traffic_light_camera_blueprint(blueprint_library):
+    """Generates a traffic light camera
+
+    The following assumptions were made based on the configuration in AWSIM:
+    - 10 Hz publish frequency
+    - 1920 x 1080 image resolution
+    - 90 deg horizontal field of view"""
+
+    blueprint = blueprint_library.find("sensor.camera.rgb")
+
+    blueprint.set_attribute("fov", "90.0")
+    blueprint.set_attribute("image_size_x", "1920")
+    blueprint.set_attribute("image_size_y", "1080")
+    blueprint.set_attribute("sensor_tick", "0.1")
+
+    return blueprint
+
+def spawn_sensors(world, base_link):
+    """Spawns sensors relatively to the provided base_link actor
+
+    Positioning of the sensors is taken from the URDF for awsim_sensor_kit_description package at:
+    https://github.com/autowarefoundation/autoware_launch/tree/0.45.3/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description
+    """
+
+    blueprint_library = world.get_blueprint_library()
+
+    empty_blueprint = blueprint_library.find("util.actor.empty")
+    vlp16_blueprint = generate_vlp16_blueprint(blueprint_library)
+    traffic_light_camera_blueprint \
+        = generate_traffic_light_camera_blueprint(blueprint_library)
+    imu_blueprint = blueprint_library.find("sensor.other.imu")
+    gnss_receiver_blueprint = blueprint_library.find("sensor.other.gnss")
+
+    sensor_kit_to_base_link_transform = carla.Transform(
+        carla.Location(x=0.9, z=2.0),
+        carla.Rotation(
+            roll=math.degrees(-0.001),
+            pitch=math.degrees(0.015),
+            yaw=math.degrees(-0.0364)))
+    sensor_kit = world.spawn_actor(
+        empty_blueprint,
+        sensor_kit_to_base_link_transform,
+        attach_to=base_link)
+
+    # Spawn top lidar
+    lidar_top_to_sensor_kit_transform = carla.Transform(
+        carla.Location(),
+        carla.Rotation(
+            yaw=math.degrees(1.575)))
+    lidar_top = world.spawn_actor(
+        vlp16_blueprint,
+        lidar_top_to_sensor_kit_transform,
+        attach_to=sensor_kit)
+    lidar_top.enable_for_ros()
+
+    # Spawn traffic light camera
+    traffic_light_left_camera_to_sensor_kit_transform = carla.Transform(
+        carla.Location(x=0.05, y=0.0175, z=-0.1))
+    traffic_light_left_camera = world.spawn_actor(
+        traffic_light_camera_blueprint,
+        traffic_light_left_camera_to_sensor_kit_transform,
+        attach_to=sensor_kit)
+    traffic_light_left_camera.enable_for_ros()
+
+    # Spawn IMU
+    imu_to_sensor_kit_transform = carla.Transform(
+        carla.Location(),
+        carla.Rotation(
+            roll=math.degrees(3.14159265359),
+            yaw=math.degrees(3.14159265359)))
+    imu = world.spawn_actor(
+        imu_blueprint,
+        imu_to_sensor_kit_transform,
+        attach_to=sensor_kit)
+    imu.enable_for_ros()
+
+    # Spawn GNSS receiver
+    gnss_receiver_to_sensor_kit_transform = carla.Transform(
+        carla.Location(x=-0.1, z=-0.2))
+    gnss_receiver = world.spawn_actor(
+        gnss_receiver_blueprint,
+        gnss_receiver_to_sensor_kit_transform,
+        attach_to=sensor_kit)
+    gnss_receiver.enable_for_ros()
+
+def spawn_ego_with_sensors(world, spawn_point):
+    """Spawns a controllable vehicle with a basic sensor configuration
+
+    The sensor configuration is compatible with the one for Lexus RX450h in AWSIM.
+    The vehicle itself is replaced by Linkoln MKZ available in CARLA."""
+
+    blueprint_library = world.get_blueprint_library()
+
+    ego_blueprint = blueprint_library.find("vehicle.lincoln.mkz")
+    empty_blueprint = blueprint_library.find("util.actor.empty")
+
+    ego = world.spawn_actor(ego_blueprint, spawn_point)
+
+    # Transformation between vehicle pivot and projection of the rear
+    # axis on the ground (base link) as measured in Unreal Editor
+    base_link_to_pivot_transform = carla.Transform(
+        carla.Location(x=-1.39706787))
+    base_link = world.spawn_actor(
+        empty_blueprint,
+        base_link_to_pivot_transform,
+        attach_to=ego)
+
+    spawn_sensors(world, base_link)
+
+    return ego
+
+def main():
+    argparser = argparse.ArgumentParser(
+        description='CARLA Automatic Control Client')
+    argparser.add_argument(
+        '-v', '--verbose', action='store_true', dest='debug',
+        help='Print debug information')
+    argparser.add_argument(
+        '--host', metavar='H', default='127.0.0.1',
+        help='IP of the host server (default: 127.0.0.1)')
+    argparser.add_argument(
+        '-p', '--port', metavar='P', default=2000, type=int,
+        help='TCP port of the host server (default: 2000)')
+    args = argparser.parse_args()
+
+    client = carla.Client(args.host, args.port)
+    client.set_timeout(60.0)
+    world = client.get_world()
+
+    spawn_point = random.choice(world.get_map().get_spawn_points())
+    spawn_ego_with_sensors(world, spawn_point)
+    print('Ego spawned!')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds a script to spawn ego vehicle with a sensor setup compatible with the one from AWSIM.
Uses the default topic names in CARLA; these will be configured in later pull requests.

## References

### URDF for the AWSIM sensor kit

Positions of each sensor are taken from the following file:
https://github.com/autowarefoundation/autoware_launch/tree/0.45.3/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description

### Configuration within AWSIM

Latest version of AWSIM v2.0.0 (tier4/AWSIM@92583dfc63ded0851521e72a279d17173ebb422d) has been checked for exact configuration of each sensor.

#### List of active sensors

Based on the screenshot below, the following subset of sensors present in URDF has been selected:
- top lidar;
- left traffic light camera;
- inertial measurement unit;
- GNSS receiver.

<img width="356" height="273" alt="image" src="https://github.com/user-attachments/assets/83bd1335-1e3b-42e0-ba20-5ec4d117f87d" />

#### Lidar configuration

Based on the screenshot below, the following lidar parameters were sourced:
- model: Velodyne VLP16
  - based on [the datasheet](https://data.ouster.io/downloads/datasheets/velodyne/Puck%20Datasheets.zip), the following parameters were sourced:
    - number of channels;
    - range;
    - horizontal and vertical field of view;
  - publish frequency;
  - horizontal resolution. 

<img width="578" height="449" alt="image" src="https://github.com/user-attachments/assets/75f4fb44-13d2-459d-af83-692da0b34e17" />

#### Camera configuration

Based on the screenshot below, camera resolution was sourced.

<img width="592" height="374" alt="image" src="https://github.com/user-attachments/assets/fed17bce-a12d-4b8d-b3da-b982a0eea2b6" />

Based on the screenshot below, camera horizontal FoV was sourced.

<img width="582" height="495" alt="image" src="https://github.com/user-attachments/assets/2e20a0fe-690b-4f21-979a-7c3299efc3ec" />