### PR TITLE
Disable TF publishing when running with Autoware

### DIFF
--- a/LibCarla/source/carla/client/World.cpp
+++ b/LibCarla/source/carla/client/World.cpp
@@ -387,5 +387,13 @@ namespace client {
     }
   }
 
+  void World::SetPublishTF(bool publish_tf) {
+    _episode.Lock()->SetPublishTF(publish_tf);
+  }
+
+  bool World::GetPublishTF() const {
+    return _episode.Lock()->GetPublishTF();
+  }
+
 } // namespace client
 } // namespace carla

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -233,6 +233,15 @@ namespace client {
 
     std::vector<std::string> GetNamesOfAllObjects() const;
 
+    /// Set whether to publish ROS2 TF information
+    void SetPublishTF(bool publish_tf);
+
+    /// Get whether ROS2 TF information is being published
+    bool GetPublishTF() const;
+
+    /// Simple test method to verify binding
+    int GetTestValue() const { return 42; }
+
   private:
 
     detail::EpisodeProxy _episode;

--- a/LibCarla/source/carla/client/World.h
+++ b/LibCarla/source/carla/client/World.h
@@ -240,7 +240,7 @@ namespace client {
     bool GetPublishTF() const;
 
     /// Simple test method to verify binding
-    int GetTestValue() const { return 42; }
+    // int GetTestValue() const { return 42; }
 
   private:
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -287,6 +287,14 @@ namespace detail {
     return _pimpl->CallAndWait<bool>("is_weather_enabled");
   }
 
+  void Client::SetPublishTF(bool publish_tf) {
+    _pimpl->AsyncCall("set_publish_tf", publish_tf);
+  }
+
+  bool Client::GetPublishTF() const {
+    return _pimpl->CallAndWait<bool>("get_publish_tf");
+  }
+
   std::vector<rpc::Actor> Client::GetActorsById(
       const std::vector<ActorId> &ids) {
     using return_t = std::vector<rpc::Actor>;

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -159,7 +159,11 @@ namespace detail {
 
     void SetWeatherParameters(const rpc::WeatherParameters &weather);
 
-    bool IsWeatherEnabled(); 
+    bool IsWeatherEnabled();
+
+    void SetPublishTF(bool publish_tf);
+
+    bool GetPublishTF() const; 
 
     std::vector<rpc::Actor> GetActorsById(const std::vector<ActorId> &ids);
 

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -263,6 +263,14 @@ namespace detail {
       return _client.IsWeatherEnabled();
     }
 
+    void SetPublishTF(bool publish_tf) {
+      _client.SetPublishTF(publish_tf);
+    }
+
+    bool GetPublishTF() const {
+      return _client.GetPublishTF();
+    }
+
     rpc::VehiclePhysicsControl GetVehiclePhysicsControl(const Vehicle &vehicle) const {
       return _client.GetVehiclePhysicsControl(vehicle.GetId());
     }

--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -159,6 +159,10 @@ void ROS2::SetTimestamp(double timestamp) {
 #endif
 }
 
+void ROS2::SetPublishTF(bool publish_tf) {
+  _publish_tf = publish_tf;
+}
+
 void ROS2::AddActorRosName(void *actor, std::string ros_name) {
   _actor_ros_name.insert({actor, ros_name});
 }
@@ -670,7 +674,7 @@ void ROS2::ProcessDataFromCamera(
           publisher->SetCameraInfoData(_seconds, _nanoseconds);
           publisher->Publish();
         }
-        if (sensors.second) {
+        if (sensors.second && _publish_tf) {
           std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
           publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
           publisher->Publish();
@@ -693,7 +697,7 @@ void ROS2::ProcessDataFromCamera(
           publisher->SetCameraInfoData(_seconds, _nanoseconds);
           publisher->Publish();
         }
-        if (sensors.second) {
+        if (sensors.second && _publish_tf) {
           std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
           publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
           publisher->Publish();
@@ -709,7 +713,7 @@ void ROS2::ProcessDataFromCamera(
           publisher->SetData(_seconds, _nanoseconds, (const int32_t*) buffer->data());
           publisher->Publish();
         }
-        if (sensors.second) {
+        if (sensors.second && _publish_tf) {
           std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
           publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
           publisher->Publish();
@@ -732,7 +736,7 @@ void ROS2::ProcessDataFromCamera(
           publisher->SetCameraInfoData(_seconds, _nanoseconds);
           publisher->Publish();
         }
-        if (sensors.second) {
+        if (sensors.second && _publish_tf) {
           std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
           publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
           publisher->Publish();
@@ -759,7 +763,7 @@ void ROS2::ProcessDataFromCamera(
           publisher->SetCameraInfoData(_seconds, _nanoseconds);
           publisher->Publish();
         }
-        if (sensors.second) {
+        if (sensors.second && _publish_tf) {
           std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
           publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
           publisher->Publish();
@@ -783,7 +787,7 @@ void ROS2::ProcessDataFromCamera(
           publisher->SetCameraInfoData(_seconds, _nanoseconds);
           publisher->Publish();
         }
-        if (sensors.second) {
+        if (sensors.second && _publish_tf) {
           std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
           publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
           publisher->Publish();
@@ -806,7 +810,7 @@ void ROS2::ProcessDataFromCamera(
           publisher->SetCameraInfoData(_seconds, _nanoseconds);
           publisher->Publish();
         }
-        if (sensors.second) {
+        if (sensors.second && _publish_tf) {
           std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
           publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
           publisher->Publish();
@@ -840,7 +844,7 @@ void ROS2::ProcessDataFromGNSS(
     publisher->SetData(_seconds, _nanoseconds, reinterpret_cast<const double*>(&data));
     publisher->Publish();
   }
-  if (sensors.second) {
+  if (sensors.second && _publish_tf) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
     publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
     publisher->Publish();
@@ -862,7 +866,7 @@ void ROS2::ProcessDataFromIMU(
     publisher->SetData(_seconds, _nanoseconds, reinterpret_cast<float*>(&accelerometer), reinterpret_cast<float*>(&gyroscope), compass);
     publisher->Publish();
   }
-  if (sensors.second) {
+  if (sensors.second && _publish_tf) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
     publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
     publisher->Publish();
@@ -892,7 +896,7 @@ void ROS2::ProcessDataFromDVS(
     publisher->SetPointCloudData(1, elements * sizeof(carla::sensor::data::DVSEvent), elements, (const uint8_t*) (buffer->data() + carla::sensor::s11n::ImageSerializer::header_offset));
     publisher->Publish();
   }
-  if (sensors.second) {
+  if (sensors.second && _publish_tf) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
     publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
     publisher->Publish();
@@ -914,7 +918,7 @@ void ROS2::ProcessDataFromLidar(
     publisher->SetData(_seconds, _nanoseconds, height, width, (float*)data._points.data());
     publisher->Publish();
   }
-  if (sensors.second) {
+  if (sensors.second && _publish_tf) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
     publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
     publisher->Publish();
@@ -937,7 +941,7 @@ void ROS2::ProcessDataFromSemanticLidar(
     publisher->SetData(_seconds, _nanoseconds, 6, height, width, (float*)data._ser_points.data());
     publisher->Publish();
   }
-  if (sensors.second) {
+  if (sensors.second && _publish_tf) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
     publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
     publisher->Publish();
@@ -960,7 +964,7 @@ void ROS2::ProcessDataFromRadar(
     publisher->SetData(_seconds, _nanoseconds, height, width, elements, (const uint8_t*)data._detections.data());
     publisher->Publish();
   }
-  if (sensors.second) {
+  if (sensors.second && _publish_tf) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
     publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
     publisher->Publish();
@@ -991,7 +995,7 @@ void ROS2::ProcessDataFromCollisionSensor(
     publisher->SetData(_seconds, _nanoseconds, other_actor, impulse.x, impulse.y, impulse.z);
     publisher->Publish();
   }
-  if (sensors.second) {
+  if (sensors.second && _publish_tf) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);
     publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_transform.location, (const float*)&sensor_transform.rotation);
     publisher->Publish();

--- a/LibCarla/source/carla/ros2/ROS2.h
+++ b/LibCarla/source/carla/ros2/ROS2.h
@@ -65,6 +65,10 @@ class ROS2
   void SetFrame(uint64_t frame);
   void SetTimestamp(double timestamp);
 
+  // TF publishing control
+  void SetPublishTF(bool publish_tf);
+  bool GetPublishTF() const { return _publish_tf; }
+
   // ros_name managing
   void AddActorRosName(void *actor, std::string ros_name);
   void AddActorParentRosName(void *actor, void* parent);
@@ -166,6 +170,7 @@ void ProcessDataFromCollisionSensor(
   static std::shared_ptr<ROS2> _instance;
 
   bool _enabled { false };
+  bool _publish_tf { true };
   uint64_t _frame { 0 };
   int32_t _seconds { 0 };
   uint32_t _nanoseconds { 0 };

--- a/PythonAPI/carla/src/World.cpp
+++ b/PythonAPI/carla/src/World.cpp
@@ -340,6 +340,9 @@ void export_world() {
     .def("project_point", CALL_RETURNING_OPTIONAL_3(cc::World, ProjectPoint, cg::Location, cg::Vector3D, float), (arg("location"), arg("direction"), arg("search_distance")=10000.f))
     .def("ground_projection", CALL_RETURNING_OPTIONAL_2(cc::World, GroundProjection, cg::Location, float), (arg("location"), arg("search_distance")=10000.f))
     .def("get_names_of_all_objects", CALL_RETURNING_LIST(cc::World, GetNamesOfAllObjects))
+    .def("get_test_value", &cc::World::GetTestValue)
+    .def("get_publish_tf", &cc::World::GetPublishTF)
+    .def("set_publish_tf", &cc::World::SetPublishTF, (arg("publish_tf")))
     //.def("get_lightmanager", CONST_CALL_WITHOUT_GIL(cc::World, GetLightManager)) Disabling the light manager as it is not supported in 0.10.0 due to lack of night mode
     
     // All of this is deprecated:

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -154,6 +154,11 @@ def main():
     client.set_timeout(60.0)
     world = client.get_world()
 
+    # Autoware will be publishing TF information based on the URDF files
+    # of the vehicle and sensor kit. Disable TF publishing in CARLA
+    # to avoid conflicts.
+    world.set_publish_tf(False)
+
     spawn_point = random.choice(world.get_map().get_spawn_points())
     spawn_ego_with_sensors(world, spawn_point)
     print('Ego spawned!')

--- a/PythonAPI/examples/ros2/ros2_native.py
+++ b/PythonAPI/examples/ros2/ros2_native.py
@@ -76,6 +76,13 @@ def main(args):
 
         world = client.get_world()
 
+        # Disable TF publishing if requested
+        if hasattr(args, 'disable_tf') and args.disable_tf:
+            world.set_publish_tf(False)
+            logging.info("TF publishing disabled")
+        else:
+            logging.info("TF publishing enabled: %s", world.get_publish_tf())
+
         original_settings = world.get_settings()
         settings = world.get_settings()
         settings.synchronous_mode = True
@@ -120,6 +127,7 @@ if __name__ == '__main__':
     argparser.add_argument('--port', metavar='P', default=2000, type=int, help='TCP port of CARLA Simulator (default: 2000)')
     argparser.add_argument('-f', '--file', default='', required=True, help='File to be executed')
     argparser.add_argument('-v', '--verbose', action='store_true', dest='debug', help='print debug information')
+    argparser.add_argument('--disable-tf', action='store_true', dest='disable_tf', help='disable ROS2 TF publishing')
 
     args = argparser.parse_args()
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -726,6 +726,37 @@ void FCarlaServer::FPimpl::BindActions()
     return true;
   };
 
+  // ~~ ROS2 TF ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  BIND_SYNC(set_publish_tf) << [this](bool publish_tf) -> R<void>
+  {
+    #if defined(WITH_ROS2)
+    REQUIRE_CARLA_EPISODE();
+    auto ROS2 = carla::ros2::ROS2::GetInstance();
+    if (ROS2 && ROS2->IsEnabled()) {
+      ROS2->SetPublishTF(publish_tf);
+      return R<void>::Success();
+    }
+    RESPOND_ERROR("set_publish_tf: ROS2 is not enabled");
+    #else
+    RESPOND_ERROR("set_publish_tf: Server was compiled without ROS2 support");
+    #endif
+  };
+
+  BIND_SYNC(get_publish_tf) << [this]() -> R<bool>
+  {
+    #if defined(WITH_ROS2)
+    REQUIRE_CARLA_EPISODE();
+    auto ROS2 = carla::ros2::ROS2::GetInstance();
+    if (ROS2 && ROS2->IsEnabled()) {
+      return ROS2->GetPublishTF();
+    }
+    return false;
+    #else
+    return false;
+    #endif
+  };
+
   // ~~ Actor operations ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   BIND_SYNC(get_actors_by_id) << [this](


### PR DESCRIPTION

1. Adds an option to disable TF publishing from the Python API:

```
world.set_publish_tf(False)
```

2. Disables TF publishing in `PythonAPI/examples/autoware_demo.py`

**Context:** When Autoware will publish its own TF information, publishing from CARLA can cause conflicts.