### PR TITLE
Add an option to specify custom frame_id for ROS2 publishing

### DIFF
--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -175,6 +175,7 @@ void ROS2::AddActorParentRosName(void *actor, void* parent) {
 void ROS2::RemoveActorRosName(void *actor) {
   _actor_ros_name.erase(actor);
   _actor_parent_ros_name.erase(actor);
+  _actor_ros_frame_id.erase(actor);
 
   _publishers.erase(actor);
   _transforms.erase(actor);
@@ -244,6 +245,30 @@ void ROS2::UpdateActorRosTopicName(void *actor, std::string ros_topic_name) {
 std::string ROS2::GetActorRosTopicName(void *actor) {
   auto it = _actor_ros_topic_name.find(actor);
   if (it != _actor_ros_topic_name.end()) {
+    return it->second;
+  } else {
+    return std::string("");
+  }
+}
+
+void ROS2::AddActorRosFrameId(void *actor, std::string ros_frame_id) {
+  _actor_ros_frame_id.insert({actor, ros_frame_id});
+}
+
+void ROS2::RemoveActorRosFrameId(void *actor) {
+  _actor_ros_frame_id.erase(actor);
+}
+
+void ROS2::UpdateActorRosFrameId(void *actor, std::string ros_frame_id) {
+  auto it = _actor_ros_frame_id.find(actor);
+  if (it != _actor_ros_frame_id.end()) {
+    it->second = ros_frame_id;
+  }
+}
+
+std::string ROS2::GetActorRosFrameId(void *actor) {
+  auto it = _actor_ros_frame_id.find(actor);
+  if (it != _actor_ros_frame_id.end()) {
     return it->second;
   } else {
     return std::string("");
@@ -330,6 +355,7 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
     std::string ros_name = GetActorRosName(actor);
     std::string parent_ros_name = GetActorParentRosName(actor);
     std::string ros_topic_name = GetActorRosTopicName(actor);
+    std::string ros_frame_id = GetActorRosFrameId(actor);
     switch(type) {
       case ESensors::CollisionSensor: {
         if (ros_name == "collision__") {
@@ -340,6 +366,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaCollisionPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -358,6 +387,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaDepthCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -376,6 +408,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaNormalsCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -394,6 +429,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaDVSCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -412,6 +450,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaGNSSPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -438,6 +479,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           config.history_qos_depth = 1000;
           return config;
         }())) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -456,6 +500,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaLineInvasionPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -477,6 +524,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaOpticalFlowCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -495,6 +545,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaRadarPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -513,6 +566,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaSemanticLidarPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -539,6 +595,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           config.history_qos_depth = 5;
           return config;
         }())) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -580,6 +639,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           return config;
         }();
         if (new_publisher->Init(image_topic_config, info_topic_config)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -598,6 +660,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaSSCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }
@@ -616,6 +681,9 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
         }
         auto new_publisher = std::make_shared<CarlaISCameraPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
         if (new_publisher->Init(_domain_id)) {
+          if (!ros_frame_id.empty()) {
+            new_publisher->frame_id(std::string(ros_frame_id));
+          }
           _publishers.insert({actor, new_publisher});
           publisher = new_publisher;
         }

--- a/LibCarla/source/carla/ros2/ROS2.h
+++ b/LibCarla/source/carla/ros2/ROS2.h
@@ -79,6 +79,12 @@ class ROS2
   void UpdateActorRosTopicName(void *actor, std::string ros_name);
   std::string GetActorRosTopicName(void *actor);
 
+  // ros_frame_id managing
+  void AddActorRosFrameId(void *actor, std::string ros_frame_id);
+  void RemoveActorRosFrameId(void *actor);
+  void UpdateActorRosFrameId(void *actor, std::string ros_frame_id);
+  std::string GetActorRosFrameId(void *actor);
+
   // callbacks
   void AddActorCallback(void* actor, std::string ros_name, ActorCallback callback);
   void RemoveActorCallback(void* actor);
@@ -172,6 +178,7 @@ void ProcessDataFromCollisionSensor(
   uint32_t _domain_id { 0U };
   std::unordered_map<void *, std::string> _actor_ros_name;
   std::unordered_map<void *, std::string> _actor_ros_topic_name;
+  std::unordered_map<void *, std::string> _actor_ros_frame_id;
   std::unordered_map<void *, std::vector<void*> > _actor_parent_ros_name;
   std::shared_ptr<CarlaEgoVehicleControlSubscriber> _controller;
   std::shared_ptr<AutowareController> _autoware_controller;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -229,6 +229,15 @@ static void FillIdAndTags(FActorDefinition &Def, TStrs &&...Strings)
     Var.bRestrictToRecommended = false;
     Def.Variations.Emplace(Var);
   }
+
+  {
+    FActorVariation Var;
+    Var.Id = TEXT("ros_frame_id");
+    Var.Type = EActorAttributeType::String;
+    Var.RecommendedValues = {Def.Id};
+    Var.bRestrictToRecommended = false;
+    Def.Variations.Emplace(Var);
+  }
 }
 
 static void AddRecommendedValuesForActorRoleName(

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
@@ -179,6 +179,7 @@ FCarlaActor* UActorDispatcher::RegisterActor(
       // actor ros_name
       std::string RosName;
       std::string RosTopicName;
+      std::string RosFrameId;
       for (auto &&Attr : Description.Variations)
       {
         if (Attr.Key == "ros_name")
@@ -188,6 +189,10 @@ FCarlaActor* UActorDispatcher::RegisterActor(
         if (Attr.Key == "ros_topic_name")
         {
           RosTopicName = std::string(TCHAR_TO_UTF8(*Attr.Value.Value));
+        }
+        if (Attr.Key == "ros_frame_id")
+        {
+          RosFrameId = std::string(TCHAR_TO_UTF8(*Attr.Value.Value));
         }
       }
       const std::string id = std::string(TCHAR_TO_UTF8(*Description.Id));
@@ -209,6 +214,7 @@ FCarlaActor* UActorDispatcher::RegisterActor(
         ROS2->AddActorRosName(static_cast<void*>(&Actor), RosName);
       }
       ROS2->AddActorRosTopicName(static_cast<void*>(&Actor), RosTopicName == id ? "" : RosTopicName);  // empty is signal to generate default topic by sensor
+      ROS2->AddActorRosFrameId(static_cast<void*>(&Actor), RosFrameId);
 
       // vehicle controller for hero
       for (auto &&Attr : Description.Variations)


### PR DESCRIPTION
Adds an option to specify custom frame_id for sensors which publish to ROS2:

```
bp = bp_library.blueprint_library.find("some.sensor.id")
bp.set_attribute("ros_frame_id", "my_tf_link")
world.spawn(bp, carla.Position())
```