### PR TITLE
Restore `frame_id` in Autoware publishers

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/AutowarePublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/AutowarePublisher.cpp
@@ -29,6 +29,7 @@ struct PublisherTraits;
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::VelocityReport> {
   using PubSub = autoware_vehicle_msgs::msg::VelocityReportPubSubType;
+  static constexpr const char* frame_id = "base_line";
   static constexpr const char* topic = "/vehicle/status/velocity_status";
   static constexpr const char* human_name = "Autoware velocity report";
 };
@@ -36,6 +37,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::VelocityReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::SteeringReport> {
   using PubSub = autoware_vehicle_msgs::msg::SteeringReportPubSubType;
+  static constexpr const char* frame_id = "";
   static constexpr const char* topic = "/vehicle/status/steering_status";
   static constexpr const char* human_name = "Autoware steering report";
 };
@@ -43,6 +45,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::SteeringReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::ControlModeReport> {
   using PubSub = autoware_vehicle_msgs::msg::ControlModeReportPubSubType;
+  static constexpr const char* frame_id = "";
   static constexpr const char* topic = "/vehicle/status/control_mode";
   static constexpr const char* human_name = "Autoware control mode report";
 };
@@ -50,6 +53,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::ControlModeReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::GearReport> {
   using PubSub = autoware_vehicle_msgs::msg::GearReportPubSubType;
+  static constexpr const char* frame_id = "";
   static constexpr const char* topic = "/vehicle/status/gear_status";
   static constexpr const char* human_name = "Autoware gear report";
 };
@@ -57,6 +61,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::GearReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::TurnIndicatorsReport> {
   using PubSub = autoware_vehicle_msgs::msg::TurnIndicatorsReportPubSubType;
+  static constexpr const char* frame_id = "";
   static constexpr const char* topic = "/vehicle/status/turn_indicators_status";
   static constexpr const char* human_name = "Autoware turn indicators report";
 };
@@ -64,6 +69,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::TurnIndicatorsReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::HazardLightsReport> {
   using PubSub = autoware_vehicle_msgs::msg::HazardLightsReportPubSubType;
+  static constexpr const char* frame_id = "";
   static constexpr const char* topic = "/vehicle/status/hazard_lights_status";
   static constexpr const char* human_name = "Autoware hazard lights report";
 };
@@ -75,7 +81,7 @@ public:
   using Base = AutowarePublisherBase<Msg, typename PublisherTraits<Msg>::PubSub>;
 
   ReportPublisher()
-    : Base("", "", PublisherTraits<Msg>::topic) {}
+    : Base(PublisherTraits<Msg>::frame_id, "", PublisherTraits<Msg>::topic) {}
 
   const char* type() const override {
     return PublisherTraits<Msg>::human_name;


### PR DESCRIPTION
Set `frame_id` for publishers in `AutowarePublisher` class.

This change restores functionality originally introduced in #5 where `frame_id` was set.
During the review - which included a refactoring - the `frame_id` setting was omitted.