### PR TITLE
Feature: Add custom vehicle sensor support

### DIFF
--- a/LibCarla/source/carla/sensor/SensorRegistry.h
+++ b/LibCarla/source/carla/sensor/SensorRegistry.h
@@ -29,6 +29,7 @@
 #include "carla/sensor/s11n/SemanticLidarSerializer.h"
 #include "carla/sensor/s11n/GBufferUint8Serializer.h"
 #include "carla/sensor/s11n/GBufferFloatSerializer.h"
+#include "carla/sensor/s11n/VehicleStatusSerializer.h" // Autoware
 
 // 2. Add a forward-declaration of the sensor here.
 class ACollisionSensor;
@@ -50,6 +51,7 @@ class ARssSensor;
 class FWorldObserver;
 struct FCameraGBufferUint8;
 struct FCameraGBufferFloat;
+class AVehicleStatusSensor; // Autoware
 
 namespace carla {
 namespace sensor {
@@ -80,7 +82,8 @@ namespace sensor {
     std::pair<AInstanceSegmentationCamera *, s11n::ImageSerializer>,
     std::pair<FWorldObserver *, s11n::EpisodeStateSerializer>,
     std::pair<FCameraGBufferUint8 *, s11n::GBufferUint8Serializer>,
-    std::pair<FCameraGBufferFloat *, s11n::GBufferFloatSerializer>
+    std::pair<FCameraGBufferFloat *, s11n::GBufferFloatSerializer>,
+    std::pair<AVehicleStatusSensor *, s11n::VehicleStatusSerializer> // Autoware
   >;
 
 } // namespace sensor
@@ -108,5 +111,6 @@ namespace sensor {
 #include "Carla/Sensor/SemanticSegmentationCamera.h"
 #include "Carla/Sensor/InstanceSegmentationCamera.h"
 #include "Carla/Sensor/WorldObserver.h"
+#include "Carla/Sensor/Autoware/VehicleStatusSensor.h" // Autoware
 
 #endif // LIBCARLA_SENSOR_REGISTRY_WITH_SENSOR_INCLUDES

--- a/LibCarla/source/carla/sensor/data/VehicleStatusEvent.h
+++ b/LibCarla/source/carla/sensor/data/VehicleStatusEvent.h
@@ -20,10 +20,21 @@ namespace data {
   public:
 
     double GetTimestamp() const { return _parsed.timestamp; }
+
     float GetSpeed() const { return _parsed.speed_mps; }
-    float GetVelX() const { return _parsed.vel_x_mps; }
-    float GetVelY() const { return _parsed.vel_y_mps; }
-    float GetVelZ() const { return _parsed.vel_z_mps; }
+    float GetVelX() const { return _parsed.vel_x_mps; } // local
+    float GetVelY() const { return _parsed.vel_y_mps; } // local
+    float GetVelZ() const { return _parsed.vel_z_mps; } // local
+
+    float GetAngVelX() const { return _parsed.angVel_x_mps; } // local
+    float GetAngVelY() const { return _parsed.angVel_y_mps; } // local
+    float GetAngVelZ() const { return _parsed.angVel_z_mps; } // local
+
+    float GetRotrPitch() const { return _parsed.rotr_pitch; } // local
+    float GetRotrYaw() const { return _parsed.rotr_yaw; } // local
+    float GetRotrRoll() const { return _parsed.rotr_roll; } // local
+    
+
     float GetSteer() const { return _parsed.steer; }
     int32_t GetGear() const { return _parsed.gear; }
     uint8_t GetTurnMask() const { return _parsed.turn_mask; }

--- a/LibCarla/source/carla/sensor/data/VehicleStatusEvent.h
+++ b/LibCarla/source/carla/sensor/data/VehicleStatusEvent.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "carla/sensor/SensorData.h"
+#include "carla/sensor/s11n/VehicleStatusSerializer.h"
+
+namespace carla {
+namespace sensor {
+namespace data {
+
+  class VehicleStatusEvent : public SensorData {
+    using Super = SensorData;
+  protected:
+    using Serializer = s11n::VehicleStatusSerializer;
+    friend Serializer;
+
+    explicit VehicleStatusEvent(const RawData &data)
+      : Super(data),
+        _parsed(Serializer::DeserializeRawData(data)) {}
+
+  public:
+
+    double GetTimestamp() const { return _parsed.timestamp; }
+    float GetSpeed() const { return _parsed.speed_mps; }
+    float GetVelX() const { return _parsed.vel_x_mps; }
+    float GetVelY() const { return _parsed.vel_y_mps; }
+    float GetVelZ() const { return _parsed.vel_z_mps; }
+    float GetSteer() const { return _parsed.steer; }
+    int32_t GetGear() const { return _parsed.gear; }
+    uint8_t GetTurnMask() const { return _parsed.turn_mask; }
+    uint8_t GetControlFlags() const { return _parsed.control_flags; }
+
+  private:
+    Serializer::Data _parsed;
+  };
+
+} // namespace data
+} // namespace sensor
+} // namespace carla

--- a/LibCarla/source/carla/sensor/data/VehicleStatusEvent.h
+++ b/LibCarla/source/carla/sensor/data/VehicleStatusEvent.h
@@ -34,7 +34,6 @@ namespace data {
     float GetRotrYaw() const { return _parsed.rotr_yaw; } // local
     float GetRotrRoll() const { return _parsed.rotr_roll; } // local
     
-
     float GetSteer() const { return _parsed.steer; }
     int32_t GetGear() const { return _parsed.gear; }
     uint8_t GetTurnMask() const { return _parsed.turn_mask; }

--- a/LibCarla/source/carla/sensor/s11n/VehicleStatusSerializer.cpp
+++ b/LibCarla/source/carla/sensor/s11n/VehicleStatusSerializer.cpp
@@ -1,0 +1,13 @@
+#include "carla/sensor/data/VehicleStatusEvent.h"
+#include "VehicleStatusSerializer.h"
+
+namespace carla {
+namespace sensor {
+namespace s11n {
+
+  SharedPtr<SensorData> VehicleStatusSerializer::Deserialize(RawData &&data) {
+    return SharedPtr<SensorData>(new data::VehicleStatusEvent(std::move(data)));
+  }
+} // namespace s11n
+} // namespace sensor
+} // namespace carla

--- a/LibCarla/source/carla/sensor/s11n/VehicleStatusSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/VehicleStatusSerializer.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "carla/Buffer.h"
+#include "carla/Memory.h"
+#include "carla/sensor/RawData.h"
+#include "carla/sensor/SensorData.h"
+
+namespace carla {
+namespace sensor {
+namespace s11n {
+
+class VehicleStatusSerializer {
+public:
+
+  struct Data {
+    double timestamp;
+    float speed_mps;
+    float vel_x_mps, vel_y_mps, vel_z_mps;
+    float steer;
+    int32_t gear;
+    uint8_t turn_mask;
+    uint8_t control_flags;
+
+    MSGPACK_DEFINE_ARRAY(timestamp,
+                         speed_mps,
+                         vel_x_mps, vel_y_mps, vel_z_mps,
+                         steer,
+                         gear,
+                         turn_mask,
+                         control_flags)
+  };
+
+  constexpr static auto header_offset = 0u;
+  
+  static Data DeserializeRawData(const RawData &message) {
+    return MsgPack::UnPack<Data>(message.begin(), message.size());
+  }
+
+  // Existing 10-argument version (for direct calls)
+  template <typename SensorT>
+  static Buffer Serialize(
+      const SensorT &,
+      double timestamp,
+      float speed_mps,
+      float vel_x_mps,
+      float vel_y_mps,
+      float vel_z_mps,
+      float steer,
+      int32_t gear,
+      uint8_t turn_mask,
+      uint8_t control_flags) {
+    return MsgPack::Pack(Data{
+        timestamp,
+        speed_mps,
+        vel_x_mps, vel_y_mps, vel_z_mps,
+        steer,
+        gear,
+        turn_mask,
+        control_flags});
+  }
+
+  // New overload for CompositeSerializer / Unreal
+  template <typename SensorT>
+  static Buffer Serialize(const SensorT &sensor, const Buffer &buffer) {
+    // Convert Unreal’s Packed struct to MsgPack
+    struct Packed {
+      double timestamp;
+      float speed_mps;
+      float vel_x_mps, vel_y_mps, vel_z_mps;
+      float steer;
+      int32_t gear;
+      uint8_t turn_mask;
+      uint8_t control_flags;
+      uint8_t _pad0;
+      uint8_t _pad1;
+    } PACKED;
+
+    if (buffer.size() != sizeof(Packed)) {
+      throw std::runtime_error("Invalid buffer size for VehicleStatusSensor");
+    }
+
+    Packed msg;
+    std::memcpy(&msg, buffer.data(), sizeof(Packed));
+
+    return MsgPack::Pack(Data{
+        msg.timestamp,
+        msg.speed_mps,
+        msg.vel_x_mps, msg.vel_y_mps, msg.vel_z_mps,
+        msg.steer,
+        msg.gear,
+        msg.turn_mask,
+        msg.control_flags});
+  }
+
+  static SharedPtr<SensorData> Deserialize(RawData &&data);
+};
+
+} // namespace s11n
+} // namespace sensor
+} // namespace carla

--- a/LibCarla/source/carla/sensor/s11n/VehicleStatusSerializer.h
+++ b/LibCarla/source/carla/sensor/s11n/VehicleStatusSerializer.h
@@ -15,7 +15,9 @@ public:
   struct Data {
     double timestamp;
     float speed_mps;
-    float vel_x_mps, vel_y_mps, vel_z_mps;
+    float vel_x_mps, vel_y_mps, vel_z_mps; // local
+    float angVel_x_mps, angVel_y_mps, angVel_z_mps; // local
+    float rotr_pitch, rotr_yaw, rotr_roll; // local
     float steer;
     int32_t gear;
     uint8_t turn_mask;
@@ -24,6 +26,8 @@ public:
     MSGPACK_DEFINE_ARRAY(timestamp,
                          speed_mps,
                          vel_x_mps, vel_y_mps, vel_z_mps,
+                         angVel_x_mps, angVel_y_mps, angVel_z_mps,
+                         rotr_pitch, rotr_yaw, rotr_roll,
                          steer,
                          gear,
                          turn_mask,
@@ -36,7 +40,7 @@ public:
     return MsgPack::UnPack<Data>(message.begin(), message.size());
   }
 
-  // Existing 10-argument version (for direct calls)
+  // Existing version for direct calls
   template <typename SensorT>
   static Buffer Serialize(
       const SensorT &,
@@ -45,6 +49,12 @@ public:
       float vel_x_mps,
       float vel_y_mps,
       float vel_z_mps,
+      float angVel_x_mps,
+      float angVel_y_mps,
+      float angVel_z_mps,
+      float rotr_pitch,
+      float rotr_yaw,
+      float rotr_roll,
       float steer,
       int32_t gear,
       uint8_t turn_mask,
@@ -53,6 +63,8 @@ public:
         timestamp,
         speed_mps,
         vel_x_mps, vel_y_mps, vel_z_mps,
+        angVel_x_mps, angVel_y_mps, angVel_z_mps,
+        rotr_pitch, rotr_yaw, rotr_roll,
         steer,
         gear,
         turn_mask,
@@ -66,7 +78,9 @@ public:
     struct Packed {
       double timestamp;
       float speed_mps;
-      float vel_x_mps, vel_y_mps, vel_z_mps;
+      float vel_x_mps, vel_y_mps, vel_z_mps; // local
+      float angVel_x_mps, angVel_y_mps, angVel_z_mps; // local
+      float rotr_pitch, rotr_yaw, rotr_roll; // local
       float steer;
       int32_t gear;
       uint8_t turn_mask;
@@ -86,6 +100,8 @@ public:
         msg.timestamp,
         msg.speed_mps,
         msg.vel_x_mps, msg.vel_y_mps, msg.vel_z_mps,
+        msg.angVel_x_mps, msg.angVel_y_mps, msg.angVel_z_mps,
+        msg.rotr_pitch, msg.rotr_yaw, msg.rotr_roll,
         msg.steer,
         msg.gear,
         msg.turn_mask,

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -57,6 +57,7 @@ def spawn_sensors(world, base_link):
         = generate_traffic_light_camera_blueprint(blueprint_library)
     imu_blueprint = blueprint_library.find("sensor.other.imu")
     gnss_receiver_blueprint = blueprint_library.find("sensor.other.gnss")
+    vehicle_status_blueprint = blueprint_library.find("sensor.other.vehicle_status")
 
     sensor_kit_to_base_link_transform = carla.Transform(
         carla.Location(x=0.9, z=2.0),
@@ -109,6 +110,15 @@ def spawn_sensors(world, base_link):
         gnss_receiver_to_sensor_kit_transform,
         attach_to=sensor_kit)
     gnss_receiver.enable_for_ros()
+
+    # Spawn Vehicle Status Sensor
+    vehicle_status_to_sensor_kit_transform = carla.Transform(
+        carla.Location(x=0.0, z=0.5))
+    vehicle_status_sensor = world.spawn_actor(
+        vehicle_status_blueprint,
+        vehicle_status_to_sensor_kit_transform,
+        attach_to=sensor_kit)
+    vehicle_status_sensor.enable_for_ros()
 
 def spawn_ego_with_sensors(world, spawn_point):
     """Spawns a controllable vehicle with a basic sensor configuration

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -49,11 +49,21 @@ void AVehicleStatusSensor::BeginPlay()
   Super::BeginPlay();
   Parent = GetAttachParentActor();
   ResolveVehicle();
+  SecondsPerUpdate = 1.0f / TargetRateHz;
 }
 
 void AVehicleStatusSensor::PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds)
 {
   Super::PostPhysTick(World, TickType, DeltaSeconds);
+
+  // Throttle publishing to defined Hz rate
+  const double CurrentTime = GetWorld()->GetTimeSeconds();
+  if (CurrentTime - LastSentTimestamp < SecondsPerUpdate)
+  {
+    return;
+  }
+  LastSentTimestamp = CurrentTime;
+  
   CollectAndStream(DeltaSeconds);
 }
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -14,6 +14,9 @@ AVehicleStatusSensor::AVehicleStatusSensor(const FObjectInitializer& ObjectIniti
 {
   PrimaryActorTick.bCanEverTick = true;
   PrimaryActorTick.TickGroup = TG_PostPhysics;  // read ground-truth after physics update
+  
+  TargetRateHz = FMath::Clamp(TargetRateHz, MinRateHz, MaxRateHz);
+  PrimaryActorTick.TickInterval = 1.0f / TargetRateHz;
 }
 
 FActorDefinition AVehicleStatusSensor::GetSensorDefinition()
@@ -49,21 +52,11 @@ void AVehicleStatusSensor::BeginPlay()
   Super::BeginPlay();
   Parent = GetAttachParentActor();
   ResolveVehicle();
-  SecondsPerUpdate = 1.0f / TargetRateHz;
 }
 
 void AVehicleStatusSensor::PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds)
 {
   Super::PostPhysTick(World, TickType, DeltaSeconds);
-
-  // Throttle publishing to defined Hz rate
-  const double CurrentTime = GetWorld()->GetTimeSeconds();
-  if (CurrentTime - LastSentTimestamp < SecondsPerUpdate)
-  {
-    return;
-  }
-  LastSentTimestamp = CurrentTime;
-  
   CollectAndStream(DeltaSeconds);
 }
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -92,7 +92,7 @@ bool AVehicleStatusSensor::ResolveVehicle()
     Vehicle = CWV;
     return true;
   }
-  
+
   return false;
 }
 
@@ -109,12 +109,8 @@ void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
     return;
   }
 
-  // Velocity
-  const FVector V_cmps = VehicleActor->GetVelocity();
-  const float speed_mps = CmpsToMps(V_cmps.Size());
-  const float vel_x_mps = CmpsToMps(V_cmps.X);
-  const float vel_y_mps = CmpsToMps(V_cmps.Y);
-  const float vel_z_mps = CmpsToMps(V_cmps.Z);
+  // Update cached velocity info
+  SetVelocityInfo(VehicleActor);
 
   // Steering & control
   float steer = 0.0f;
@@ -122,10 +118,11 @@ void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
   bool reverse = false;
   int32 current_gear = 0;
 
-  if (auto* CWV = Cast<ACarlaWheeledVehicle>(VehicleActor)) {
+  if (auto* CWV = Cast<ACarlaWheeledVehicle>(VehicleActor))
+  {
     const auto Control = CWV->GetVehicleControl();
-    steer = Control.Steer;
-    reverse = Control.bReverse;
+    steer       = Control.Steer;
+    reverse     = Control.bReverse;
     manual_gear = Control.bManualGearShift;
     current_gear = CWV->GetVehicleCurrentGear();
   }
@@ -143,28 +140,35 @@ void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
   struct Packed
   {
     double timestamp;
-    float  speed_mps;
-    float  vel_x_mps, vel_y_mps, vel_z_mps;
-    float  steer;
-    int32  gear;
-    uint8  turn_mask;
-    uint8  control_flags;
-    uint8  _pad0;
-    uint8  _pad1;
+    float speed_mps;
+    float vel_x_mps, vel_y_mps, vel_z_mps; // local
+    float angVel_x_mps, angVel_y_mps, angVel_z_mps; // local
+    float rotr_pitch, rotr_yaw, rotr_roll; // local
+    float steer;
+    int32 gear;
+    uint8 turn_mask;
+    uint8 control_flags;
+    uint8 _pad0;
+    uint8 _pad1;
   } PACKED;
 
   Packed msg{};
   msg.timestamp = GetWorld()->GetTimeSeconds();
-  msg.speed_mps = speed_mps;
-  msg.vel_x_mps = vel_x_mps;
-  msg.vel_y_mps = vel_y_mps;
-  msg.vel_z_mps = vel_z_mps;
+  msg.speed_mps = VelocityInfo.GetSpeed();
+  msg.vel_x_mps = VelocityInfo.LocalVelocity.X;
+  msg.vel_y_mps = VelocityInfo.LocalVelocity.Y;
+  msg.angVel_x_mps = VelocityInfo.LocalAngularVelocity.X;
+  msg.angVel_y_mps = VelocityInfo.LocalAngularVelocity.Y;
+  msg.angVel_z_mps = VelocityInfo.LocalAngularVelocity.Z;
+  msg.rotr_pitch = VelocityInfo.LocalRotationRate.Pitch;
+  msg.rotr_yaw = VelocityInfo.LocalRotationRate.Yaw;
+  msg.rotr_roll = VelocityInfo.LocalRotationRate.Roll;
   msg.steer = steer;
   msg.gear = current_gear;
   msg.turn_mask   = (left_blinker ? 0x01 : 0) | (right_blinker ? 0x02 : 0) | (hazard ? 0x04 : 0);
   msg.control_flags = (reverse ? 0x01 : 0) | (manual_gear ? 0x02 : 0);
 
-  // Send via new Carla UE5 API
+  // Send via Carla UE5 API
   if (AreClientsListening())
   {
     TArray<uint8> Buffer;
@@ -176,4 +180,32 @@ void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
         TArrayView<uint8>(Buffer),
         FCarlaEngine::GetFrameCounter());
   }
+}
+
+void AVehicleStatusSensor::SetVelocityInfo(const AActor* VehicleActor)
+{
+  if (!VehicleActor) return;
+
+  // World linear velocity (cm/s)
+  const FVector WorldVel_cmps = VehicleActor->GetVelocity();
+
+  // Convert to m/s, then rotate into local space
+  const FQuat InvRot = VehicleActor->GetActorTransform().GetRotation().Inverse();
+  VelocityInfo.LocalVelocity = InvRot.RotateVector(CmpsToMps(WorldVel_cmps));
+
+  // Physics angular velocity (rad/s, world space)
+  FVector WorldAngVel = FVector::ZeroVector;
+  if (UPrimitiveComponent* RootPrim = Cast<UPrimitiveComponent>(VehicleActor->GetRootComponent()))
+  {
+    if (RootPrim->IsSimulatingPhysics())
+    {
+      WorldAngVel = RootPrim->GetPhysicsAngularVelocityInRadians();
+    }
+  }
+
+  // Rotate into local space
+  VelocityInfo.LocalAngularVelocity = InvRot.RotateVector(WorldAngVel);
+
+  // Convert angular velocity vector into a Rotator for convenience
+  VelocityInfo.LocalRotationRate = VelocityInfo.LocalAngularVelocity.Rotation();
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -110,7 +110,7 @@ void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
   }
 
   // Update cached velocity info
-  SetVelocityInfo(VehicleActor);
+  SetVelocityInfoToLocal(VehicleActor);
 
   // Steering & control
   float steer = 0.0f;
@@ -155,14 +155,14 @@ void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
   Packed msg{};
   msg.timestamp = GetWorld()->GetTimeSeconds();
   msg.speed_mps = VelocityInfo.GetSpeed();
-  msg.vel_x_mps = VelocityInfo.LocalVelocity.X;
-  msg.vel_y_mps = VelocityInfo.LocalVelocity.Y;
-  msg.angVel_x_mps = VelocityInfo.LocalAngularVelocity.X;
-  msg.angVel_y_mps = VelocityInfo.LocalAngularVelocity.Y;
-  msg.angVel_z_mps = VelocityInfo.LocalAngularVelocity.Z;
-  msg.rotr_pitch = VelocityInfo.LocalRotationRate.Pitch;
-  msg.rotr_yaw = VelocityInfo.LocalRotationRate.Yaw;
-  msg.rotr_roll = VelocityInfo.LocalRotationRate.Roll;
+  msg.vel_x_mps = VelocityInfo.Velocity.X;
+  msg.vel_y_mps = VelocityInfo.Velocity.Y;
+  msg.angVel_x_mps = VelocityInfo.AngularVelocity.X;
+  msg.angVel_y_mps = VelocityInfo.AngularVelocity.Y;
+  msg.angVel_z_mps = VelocityInfo.AngularVelocity.Z;
+  msg.rotr_pitch = VelocityInfo.RotationRate.Pitch;
+  msg.rotr_yaw = VelocityInfo.RotationRate.Yaw;
+  msg.rotr_roll = VelocityInfo.RotationRate.Roll;
   msg.steer = steer;
   msg.gear = current_gear;
   msg.turn_mask   = (left_blinker ? 0x01 : 0) | (right_blinker ? 0x02 : 0) | (hazard ? 0x04 : 0);
@@ -182,7 +182,7 @@ void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
   }
 }
 
-void AVehicleStatusSensor::SetVelocityInfo(const AActor* VehicleActor)
+void AVehicleStatusSensor::SetVelocityInfoToLocal(const AActor* VehicleActor)
 {
   if (!VehicleActor) return;
 
@@ -191,7 +191,7 @@ void AVehicleStatusSensor::SetVelocityInfo(const AActor* VehicleActor)
 
   // Convert to m/s, then rotate into local space
   const FQuat InvRot = VehicleActor->GetActorTransform().GetRotation().Inverse();
-  VelocityInfo.LocalVelocity = InvRot.RotateVector(CmpsToMps(WorldVel_cmps));
+  VelocityInfo.Velocity = InvRot.RotateVector(CmpsToMps(WorldVel_cmps));
 
   // Physics angular velocity (rad/s, world space)
   FVector WorldAngVel = FVector::ZeroVector;
@@ -204,8 +204,8 @@ void AVehicleStatusSensor::SetVelocityInfo(const AActor* VehicleActor)
   }
 
   // Rotate into local space
-  VelocityInfo.LocalAngularVelocity = InvRot.RotateVector(WorldAngVel);
+  VelocityInfo.AngularVelocity = InvRot.RotateVector(WorldAngVel);
 
   // Convert angular velocity vector into a Rotator for convenience
-  VelocityInfo.LocalRotationRate = VelocityInfo.LocalAngularVelocity.Rotation();
+  VelocityInfo.RotationRate = VelocityInfo.AngularVelocity.Rotation();
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -52,6 +52,7 @@ void AVehicleStatusSensor::BeginPlay()
   Super::BeginPlay();
   Parent = GetAttachParentActor();
   ResolveVehicle();
+  UE_LOG(LogTemp, Warning, TEXT("VehicleStatusSensor spawned and attached!"));
 }
 
 void AVehicleStatusSensor::PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
 // This work is licensed under the terms of the MIT license. For a copy, see <https://opensource.org/licenses/MIT>.
 
-
 #include "Sensor/Autoware/VehicleStatusSensor.h"
 
 #include "Carla/Game/CarlaEpisode.h"

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB). This work is licensed under the terms of the MIT license. For a copy, see <https://opensource.org/licenses/MIT>.
+
+
+#include "Sensor/Autoware/VehicleStatusSensor.h"
+
+#include "Carla/Game/CarlaEpisode.h"
+#include "Carla/Vehicle/CarlaWheeledVehicle.h"
+#include "Carla/Vehicle/VehicleLightState.h"  
+#include "Engine/World.h"
+#include "Carla/Sensor/Sensor.h"
+#include "Carla/Game/CarlaEngine.h"
+
+AVehicleStatusSensor::AVehicleStatusSensor(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+  PrimaryActorTick.bCanEverTick = true;
+  PrimaryActorTick.TickGroup = TG_PostPhysics;  // read ground-truth after physics update
+}
+
+FActorDefinition AVehicleStatusSensor::GetSensorDefinition()
+{
+  using namespace carla::rpc;
+
+  FActorDefinition Definition;
+
+  Definition.UId = 0;  // Carla usually ignores, spawner sets it
+  Definition.Id = TEXT("sensor.other.vehicle_status");
+  Definition.Class = StaticClass();
+  Definition.Tags = TEXT("sensor,other,vehicle_status");
+
+  // Optional attributes exposed in Python API
+  {
+    FActorAttribute SpeedUnits;
+    SpeedUnits.Id = TEXT("speed_units");
+    SpeedUnits.Type = EActorAttributeType::String;
+    SpeedUnits.Value = TEXT("mps");
+    Definition.Attributes.Emplace(MoveTemp(SpeedUnits));
+  }
+
+  return Definition;
+}
+
+void AVehicleStatusSensor::Set(const FActorDescription &ActorDescription)
+{
+  Super::Set(ActorDescription);
+}
+
+void AVehicleStatusSensor::BeginPlay()
+{
+  Super::BeginPlay();
+  Parent = GetAttachParentActor();
+  ResolveVehicle();
+}
+
+void AVehicleStatusSensor::PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds)
+{
+  Super::PostPhysTick(World, TickType, DeltaSeconds);
+  CollectAndStream(DeltaSeconds);
+}
+
+bool AVehicleStatusSensor::ResolveVehicle()
+{
+  if (!Parent.IsValid())
+  {
+    return false;
+  }
+  
+  if (Vehicle.IsValid())
+  {
+    return true;
+  }
+
+  AActor* ParentActor = Parent.Get();
+  if (!ParentActor)
+  {
+    ParentActor = GetAttachParentActor();
+  }
+  
+  if (!ParentActor)
+  {
+    return false;
+  }
+
+  // Try both common vehicle types
+  if (auto* WV = Cast<ACarlaWheeledVehicle>(ParentActor))
+  {
+    Vehicle = WV;
+    return true;
+  }
+  
+  if (auto* CWV = Cast<ACarlaWheeledVehicle>(ParentActor))
+  {
+    Vehicle = CWV;
+    return true;
+  }
+  
+  return false;
+}
+
+void AVehicleStatusSensor::CollectAndStream(float /*DeltaSeconds*/)
+{
+  if (!ResolveVehicle())
+  {
+    return;
+  }
+
+  AActor* VehicleActor = Vehicle.Get();
+  if (!VehicleActor)
+  {
+    return;
+  }
+
+  // Velocity
+  const FVector V_cmps = VehicleActor->GetVelocity();
+  const float speed_mps = CmpsToMps(V_cmps.Size());
+  const float vel_x_mps = CmpsToMps(V_cmps.X);
+  const float vel_y_mps = CmpsToMps(V_cmps.Y);
+  const float vel_z_mps = CmpsToMps(V_cmps.Z);
+
+  // Steering & control
+  float steer = 0.0f;
+  bool manual_gear = false;
+  bool reverse = false;
+  int32 current_gear = 0;
+
+  if (auto* CWV = Cast<ACarlaWheeledVehicle>(VehicleActor)) {
+    const auto Control = CWV->GetVehicleControl();
+    steer = Control.Steer;
+    reverse = Control.bReverse;
+    manual_gear = Control.bManualGearShift;
+    current_gear = CWV->GetVehicleCurrentGear();
+  }
+
+  // Lights / indicators
+  bool left_blinker = false, right_blinker = false, hazard = false;
+  if (auto* CWV = Cast<ACarlaWheeledVehicle>(VehicleActor)) {
+    const FVehicleLightState Lights = CWV->GetVehicleLightState();
+    left_blinker  = Lights.LeftBlinker;
+    right_blinker = Lights.RightBlinker;
+    hazard = left_blinker && right_blinker;
+  }
+
+  // Pack into message - matching LibCarla serializer
+  struct Packed
+  {
+    double timestamp;
+    float  speed_mps;
+    float  vel_x_mps, vel_y_mps, vel_z_mps;
+    float  steer;
+    int32  gear;
+    uint8  turn_mask;
+    uint8  control_flags;
+    uint8  _pad0;
+    uint8  _pad1;
+  } PACKED;
+
+  Packed msg{};
+  msg.timestamp = GetWorld()->GetTimeSeconds();
+  msg.speed_mps = speed_mps;
+  msg.vel_x_mps = vel_x_mps;
+  msg.vel_y_mps = vel_y_mps;
+  msg.vel_z_mps = vel_z_mps;
+  msg.steer = steer;
+  msg.gear = current_gear;
+  msg.turn_mask   = (left_blinker ? 0x01 : 0) | (right_blinker ? 0x02 : 0) | (hazard ? 0x04 : 0);
+  msg.control_flags = (reverse ? 0x01 : 0) | (manual_gear ? 0x02 : 0);
+
+  // Send via new Carla UE5 API
+  if (AreClientsListening())
+  {
+    TArray<uint8> Buffer;
+    Buffer.SetNumUninitialized(sizeof(Packed));
+    FMemory::Memcpy(Buffer.GetData(), &msg, sizeof(Packed));
+
+    ASensor::SendDataToClient(
+        *this,
+        TArrayView<uint8>(Buffer),
+        FCarlaEngine::GetFrameCounter());
+  }
+}

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB). This work is licensed under the terms of the MIT license. For a copy, see <https://opensource.org/licenses/MIT>.
+// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license. For a copy, see <https://opensource.org/licenses/MIT>.
 
 
 #include "Sensor/Autoware/VehicleStatusSensor.h"

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -8,7 +8,7 @@
 #include "VehicleStatusSensor.generated.h"
 
 USTRUCT(BlueprintType)
-struct FVelocityStatus
+struct FVelocityInfo
 {
 	GENERATED_BODY()
 	
@@ -21,7 +21,7 @@ struct FVelocityStatus
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Velocity")
 	FVector LocalAngularVelocity;
 
-	FVelocityStatus()
+	FVelocityInfo()
 		: LocalVelocity(FVector::ZeroVector)
 		, LocalRotationRate(FRotator::ZeroRotator)
 		, LocalAngularVelocity(FVector::ZeroVector)
@@ -62,7 +62,7 @@ private:
 	// Cached parent vehicle
 	TWeakObjectPtr<AActor> Parent;
 	TWeakObjectPtr<ACarlaWheeledVehicle> Vehicle; // AWheeledVehicle
-	FVelocityStatus VelocityInfo;
+	FVelocityInfo VelocityInfo;
 
 	// Helpers
 	bool ResolveVehicle();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -58,7 +58,12 @@ protected:
 	virtual void BeginPlay() override;
 	
 	// Publish frequency
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sensor")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sensor|Rate", meta=(ClampMin="1.0", UIMin="1.0"))
+	float MinRateHz = 1.0f;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sensor|Rate", meta=(ClampMin="1.0", UIMin="1.0"))
+	float MaxRateHz = 1000.0f;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sensor|Rate", meta=(ClampMin="1.0", ClampMax="1000.0", UIMin="1.0", UIMax="1000.0"))
 	float TargetRateHz = 30.0f;
 
 private:
@@ -66,10 +71,6 @@ private:
 	TWeakObjectPtr<AActor> Parent;
 	TWeakObjectPtr<ACarlaWheeledVehicle> Vehicle; // AWheeledVehicle
 	FVelocityInfo VelocityInfo;
-
-	// Publish frequency
-	float SecondsPerUpdate = 1.0f / TargetRateHz;
-	double LastSentTimestamp = 0.0;
 
 	// Helpers
 	bool ResolveVehicle();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -49,20 +49,27 @@ public:
 	static FActorDefinition GetSensorDefinition();
 
 	// Called by Carla’s spawning pipeline with user attributes
-	void Set(const FActorDescription &ActorDescription) override;
+	virtual void Set(const FActorDescription &ActorDescription) override;
+	
+	// virtual void TickActor(float DeltaTime, ELevelTick TickType, FActorTickFunction& ThisTickFunction) override; //todo might need to change into this tick if PostPhysTick() is failing
+	virtual void PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds) override;
 
 protected:
 	virtual void BeginPlay() override;
-
-public:
-	// virtual void TickActor(float DeltaTime, ELevelTick TickType, FActorTickFunction& ThisTickFunction) override; //todo might need to change into this tick if PostPhysTick() is failing
-	virtual void PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds) override;
+	
+	// Publish frequency
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Sensor")
+	float TargetRateHz = 30.0f;
 
 private:
 	// Cached parent vehicle
 	TWeakObjectPtr<AActor> Parent;
 	TWeakObjectPtr<ACarlaWheeledVehicle> Vehicle; // AWheeledVehicle
 	FVelocityInfo VelocityInfo;
+
+	// Publish frequency
+	float SecondsPerUpdate = 1.0f / TargetRateHz;
+	double LastSentTimestamp = 0.0;
 
 	// Helpers
 	bool ResolveVehicle();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -7,6 +7,33 @@
 #include "Sensor/Sensor.h"
 #include "VehicleStatusSensor.generated.h"
 
+USTRUCT(BlueprintType)
+struct FVelocityStatus
+{
+	GENERATED_BODY()
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Velocity")
+	FVector LocalVelocity;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Velocity")
+	FRotator LocalRotationRate;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Velocity")
+	FVector LocalAngularVelocity;
+
+	FVelocityStatus()
+		: LocalVelocity(FVector::ZeroVector)
+		, LocalRotationRate(FRotator::ZeroRotator)
+		, LocalAngularVelocity(FVector::ZeroVector)
+	{
+	}
+
+	float GetSpeed() const
+	{
+		return LocalVelocity.Size();
+	}
+};
+
 /**
  * 
  */
@@ -35,11 +62,17 @@ private:
 	// Cached parent vehicle
 	TWeakObjectPtr<AActor> Parent;
 	TWeakObjectPtr<ACarlaWheeledVehicle> Vehicle; // AWheeledVehicle
+	FVelocityStatus VelocityInfo;
 
 	// Helpers
 	bool ResolveVehicle();
 	void CollectAndStream(float DeltaSeconds);
+	void SetVelocityInfo(const AActor* VehicleActor);
 
 	// Scale UE velocity from cm/s to m/s
-	static inline float CmpsToMps(float v_cmps) { return v_cmps * 0.01f; }
+	template<typename T>
+	static FORCEINLINE T CmpsToMps(const T& v_cmps)
+	{
+		return v_cmps * 0.01f;
+	}
 };

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -13,24 +13,24 @@ struct FVelocityInfo
 	GENERATED_BODY()
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Velocity")
-	FVector LocalVelocity;
+	FVector Velocity;
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Velocity")
-	FRotator LocalRotationRate;
+	FRotator RotationRate;
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Velocity")
-	FVector LocalAngularVelocity;
+	FVector AngularVelocity;
 
 	FVelocityInfo()
-		: LocalVelocity(FVector::ZeroVector)
-		, LocalRotationRate(FRotator::ZeroRotator)
-		, LocalAngularVelocity(FVector::ZeroVector)
+		: Velocity(FVector::ZeroVector)
+		, RotationRate(FRotator::ZeroRotator)
+		, AngularVelocity(FVector::ZeroVector)
 	{
 	}
 
 	float GetSpeed() const
 	{
-		return LocalVelocity.Size();
+		return Velocity.Size();
 	}
 };
 
@@ -67,7 +67,7 @@ private:
 	// Helpers
 	bool ResolveVehicle();
 	void CollectAndStream(float DeltaSeconds);
-	void SetVelocityInfo(const AActor* VehicleActor);
+	void SetVelocityInfoToLocal(const AActor* VehicleActor);
 
 	// Scale UE velocity from cm/s to m/s
 	template<typename T>

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -28,7 +28,7 @@ protected:
 	virtual void BeginPlay() override;
 
 public:
-	// virtual void TickActor(float DeltaTime, ELevelTick TickType, FActorTickFunction& ThisTickFunction) override;
+	// virtual void TickActor(float DeltaTime, ELevelTick TickType, FActorTickFunction& ThisTickFunction) override; //todo might need to change into this tick if PostPhysTick() is failing
 	virtual void PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds) override;
 
 private:

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -1,4 +1,5 @@
-// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB). This work is licensed under the terms of the MIT license. For a copy, see <https://opensource.org/licenses/MIT>.
+// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB).
+// This work is licensed under the terms of the MIT license. For a copy, see <https://opensource.org/licenses/MIT>.
 
 #pragma once
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/Autoware/VehicleStatusSensor.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma de Barcelona (UAB). This work is licensed under the terms of the MIT license. For a copy, see <https://opensource.org/licenses/MIT>.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Sensor/Sensor.h"
+#include "VehicleStatusSensor.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class CARLA_API AVehicleStatusSensor : public ASensor
+{
+	GENERATED_BODY()
+
+public:
+	explicit AVehicleStatusSensor(const FObjectInitializer& ObjectInitializer);
+
+	// Carla blueprint definition (get sensor.other.vehicle_status in BP)
+	static FActorDefinition GetSensorDefinition();
+
+	// Called by Carla’s spawning pipeline with user attributes
+	void Set(const FActorDescription &ActorDescription) override;
+
+protected:
+	virtual void BeginPlay() override;
+
+public:
+	// virtual void TickActor(float DeltaTime, ELevelTick TickType, FActorTickFunction& ThisTickFunction) override;
+	virtual void PostPhysTick(UWorld* World, ELevelTick TickType, float DeltaSeconds) override;
+
+private:
+	// Cached parent vehicle
+	TWeakObjectPtr<AActor> Parent;
+	TWeakObjectPtr<ACarlaWheeledVehicle> Vehicle; // AWheeledVehicle
+
+	// Helpers
+	bool ResolveVehicle();
+	void CollectAndStream(float DeltaSeconds);
+
+	// Scale UE velocity from cm/s to m/s
+	static inline float CmpsToMps(float v_cmps) { return v_cmps * 0.01f; }
+};


### PR DESCRIPTION
## Description
`VehicleStatusSensor` Integration for UE5 + LibCarla to support:

| Topic |  Msg Type |
|--- | ---|
| /vehicle/status/velocity_status	| autoware_vehicle_msgs/VelocityReport |
|/vehicle/status/steering_status	| autoware_vehicle_msgs/SteeringReport |
| /vehicle/status/control_mode	| autoware_vehicle_msgs/ControlModeReport |
| /vehicle/status/gear_status	| autoware_vehicle_msgs/GearReport |
| /vehicle/status/turn_indicators_status |	autoware_vehicle_msgs/TurnIndicatorsReport |
| /vehicle/status/hazard_lights_status |	autoware_vehicle_msgs/HazardLightsReport |

> **Brief explanation:** Why is implementation needed on both sides?
_UE5 client generates sensor data in its native format, so it cannot directly send objects to LibCarla.
LibCarla server needs deserialization logic to interpret raw bytes into meaningful sensor data for clients._

## Changes Implemented:

1. **LibCarla (VehicleStatusSerializer + VehicleStatusEvent)**
  - Added a new VehicleStatusSerializer in LibCarla to define the data layout, Serialize and Deserialize logic.
  - Introduced header_offset constant (required by CompositeSerializer for buffer alignment).
  - Serialize packs vehicle state fields (speed, velocity vector, steering, gear, turn signals, control flags) into MsgPack format.
  - Deserialize converts raw binary data into a VehicleStatusEvent object that can be consumed by Python clients or other sensors.

2. **Unreal (AVehicleStatusSensor)**
  - Implemented packing logic in UE5 to create a Packed struct matching the LibCarla VehicleStatusSerializer::Data.
  - Populated struct with vehicle data (timestamp, speed, velocity, steering, gear, turn masks, control flags).
  - Copied struct bytes into a TArray<uint8> buffer and sent via ASensor::SendDataToClient().
  - Ensured alignment with header_offset and buffer layout expected by LibCarla.

## How it Works:

### UE5 Side

- Vehicle generates its state each frame.
- Packed struct filled and copied into a byte buffer.
- `SendDataToClient` transmits buffer to LibCarla server.

### LibCarla Side

- `VehicleStatusSerializer::Deserialize` receives raw buffer.
- Converts buffer into `VehicleStatusEvent` for use in Python or C++ APIs.
- `CompositeSerializer` can handle multiple sensors uniformly, leveraging `header_offset` for proper alignment.


