### PR TITLE
Feature: GNSS Poses publish

### DIFF
--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -18,6 +18,7 @@
 #include "carla/sensor/s11n/SensorHeaderSerializer.h"
 
 #include "publishers/AutowarePublisher.h"
+#include "publishers/AutowareGNSSPublisher.h"
 #include "publishers/CarlaPublisher.h"
 #include "publishers/CarlaClockPublisher.h"
 #include "publishers/CarlaRGBCameraPublisher.h"
@@ -410,10 +411,36 @@ std::pair<std::shared_ptr<CarlaPublisher>, std::shared_ptr<CarlaTransformPublish
           ros_name += string_id;
           UpdateActorRosName(actor, ros_name);
         }
-        auto new_publisher = std::make_shared<CarlaGNSSPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
-        if (new_publisher->Init(_domain_id)) {
-          _publishers.insert({actor, new_publisher});
-          publisher = new_publisher;
+        if (false) {  // TODO: Add some configurable switch whether the sensor is Autoware or Carla
+          auto new_publisher = std::make_shared<CarlaGNSSPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
+          if (new_publisher->Init(_domain_id)) {
+            _publishers.insert({actor, new_publisher});
+            publisher = new_publisher;
+          }
+        } else {
+          auto new_publisher = std::make_shared<AutowareGNSSPublisher>(ros_name.c_str(), parent_ros_name.c_str(), ros_topic_name.c_str());
+          if (new_publisher->Init([this]{
+            TopicConfig config;
+            config.domain_id = _domain_id;
+            config.reliability_qos = ReliabilityQoS::RELIABLE;
+            config.durability_qos = DurabilityQoS::VOLATILE;
+            config.history_qos = HistoryQoS::KEEP_LAST;
+            config.history_qos_depth = 1;
+            config.suffix = "/pose";
+            return config;
+          }(), [this]{
+            TopicConfig config;
+            config.domain_id = _domain_id;
+            config.reliability_qos = ReliabilityQoS::RELIABLE;
+            config.durability_qos = DurabilityQoS::VOLATILE;
+            config.history_qos = HistoryQoS::KEEP_LAST;
+            config.history_qos_depth = 1;
+            config.suffix = "/pose_with_covariance";
+            return config;
+          }())) {
+            _publishers.insert({actor, new_publisher});
+            publisher = new_publisher;
+          }
         }
         auto new_transform = std::make_shared<CarlaTransformPublisher>(ros_name.c_str(), parent_ros_name.c_str());
         if (new_transform->Init(_domain_id)) {
@@ -832,13 +859,18 @@ void ROS2::ProcessDataFromGNSS(
     carla::streaming::detail::stream_id_type stream_id,
     const carla::geom::Transform sensor_transform,
     const carla::geom::GeoLocation &data,
+    const carla::geom::Transform &sensor_world_transform,
     void *actor) {
   log_info("Sensor GnssSensor to ROS data: frame.", _frame, "sensor.", sensor_type, "stream.", stream_id, "geo.", data.latitude, data.longitude, data.altitude);
   auto sensors = GetOrCreateSensor(ESensors::GnssSensor, stream_id, actor);
   if (sensors.first) {
-    std::shared_ptr<CarlaGNSSPublisher> publisher = std::dynamic_pointer_cast<CarlaGNSSPublisher>(sensors.first);
-    publisher->SetData(_seconds, _nanoseconds, reinterpret_cast<const double*>(&data));
-    publisher->Publish();
+    if (std::shared_ptr<CarlaGNSSPublisher> carla_publisher = std::dynamic_pointer_cast<CarlaGNSSPublisher>(sensors.first)) {
+      carla_publisher->SetData(_seconds, _nanoseconds, reinterpret_cast<const double*>(&data));
+      carla_publisher->Publish();
+    } else if (const auto autoware_publisher = std::dynamic_pointer_cast<AutowareGNSSPublisher>(sensors.first)) {
+      autoware_publisher->SetData(_seconds, _nanoseconds, (const float*)&sensor_world_transform.location, (const float*)&sensor_world_transform.rotation);
+      autoware_publisher->Publish();
+    }
   }
   if (sensors.second) {
     std::shared_ptr<CarlaTransformPublisher> publisher = std::dynamic_pointer_cast<CarlaTransformPublisher>(sensors.second);

--- a/LibCarla/source/carla/ros2/ROS2.h
+++ b/LibCarla/source/carla/ros2/ROS2.h
@@ -103,6 +103,7 @@ class ROS2
       carla::streaming::detail::stream_id_type stream_id,
       const carla::geom::Transform sensor_transform,
       const carla::geom::GeoLocation &data,
+      const carla::geom::Transform &sensor_world_transform,
       void *actor = nullptr);
   void ProcessDataFromIMU(
       uint64_t sensor_type,

--- a/LibCarla/source/carla/ros2/publishers/AutowareGNSSPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/AutowareGNSSPublisher.cpp
@@ -52,18 +52,34 @@ bool AutowareGNSSPublisher::Publish() {
     _impl->_pose_with_covariance_publisher.Publish();
 }
 
-void AutowareGNSSPublisher::SetData(int32_t seconds, uint32_t nanoseconds, const double* position_data, const double* orientation_data) {
+void AutowareGNSSPublisher::SetData(int32_t seconds, uint32_t nanoseconds, const float* translation, const float* rotation) {
   geometry_msgs::msg::Pose pose;
 
-  // TODO: Verify whether this data layout is correct
-  pose.position().x(*position_data++);
-  pose.position().y(*position_data++);
-  pose.position().z(*position_data++);
+  /// @note: Copied from CarlaTransformPublisher
+  const float tx = *translation++;
+  const float ty = *translation++;
+  const float tz = *translation++;
 
-  pose.orientation().x(*orientation_data++);
-  pose.orientation().y(*orientation_data++);
-  pose.orientation().z(*orientation_data++);
-  pose.orientation().w(*orientation_data++);
+  const float rx = ((*rotation++) * -1.0f) * (M_PIf32 / 180.0f);
+  const float ry = ((*rotation++) * -1.0f) * (M_PIf32 / 180.0f);
+  const float rz = *rotation++ * (M_PIf32 / 180.0f);
+
+  const float cr = cosf(rz * 0.5f);
+  const float sr = sinf(rz * 0.5f);
+  const float cp = cosf(rx * 0.5f);
+  const float sp = sinf(rx * 0.5f);
+  const float cy = cosf(ry * 0.5f);
+  const float sy = sinf(ry * 0.5f);
+
+  // TODO: Verify whether this data layout is correct
+  pose.position().x(tx);
+  pose.position().y(-ty);
+  pose.position().z(tz);
+
+  pose.orientation().w(cr * cp * cy + sr * sp * sy);
+  pose.orientation().x(sr * cp * cy - cr * sp * sy);
+  pose.orientation().y(cr * sp * cy + sr * cp * sy);
+  pose.orientation().z(cr * cp * sy - sr * sp * cy);
 
   _impl->_pose_publisher.SetData(pose);
 

--- a/LibCarla/source/carla/ros2/publishers/AutowareGNSSPublisher.h
+++ b/LibCarla/source/carla/ros2/publishers/AutowareGNSSPublisher.h
@@ -26,7 +26,7 @@ class AutowareGNSSPublisher : public CarlaPublisher {
 
     bool Init(const TopicConfig& pose_config, const TopicConfig& pose_config_with_covariance_stamped);
     bool Publish();
-    void SetData(int32_t seconds, uint32_t nanoseconds, const double* position, const double* orientation);
+    void SetData(int32_t seconds, uint32_t nanoseconds, const float* position, const float* orientation);
     const char* type() const override { return "Autoware GNSS"; }
 
   private:

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -72,7 +72,7 @@ def generate_gnss_blueprint(blueprint_library):
 
     # ROS settings
     blueprint.set_attribute("ros_name", "gnss_link")  # frame_id
-    blueprint.set_attribute("ros_topic_name", "/sensing/gnss/pose")
+    blueprint.set_attribute("ros_topic_name", "/sensing/gnss")
 
     return blueprint
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/GnssSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/GnssSensor.cpp
@@ -67,14 +67,15 @@ void AGnssSensor::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaSe
     TRACE_CPUPROFILER_EVENT_SCOPE_STR("ROS2 Send");
     auto StreamId = carla::streaming::detail::token_type(GetToken()).get_stream_id();
     AActor* ParentActor = GetAttachParentActor();
+    const FTransform sensor_world_transform = GetActorTransform();
     if (ParentActor)
     {
       FTransform LocalTransformRelativeToParent = GetActorTransform().GetRelativeTransform(ParentActor->GetActorTransform());
-      ROS2->ProcessDataFromGNSS(DataStream.GetSensorType(), StreamId, LocalTransformRelativeToParent, carla::geom::GeoLocation{LatitudeValue, LongitudeValue, AltitudeValue}, this);
+      ROS2->ProcessDataFromGNSS(DataStream.GetSensorType(), StreamId, LocalTransformRelativeToParent, carla::geom::GeoLocation{LatitudeValue, LongitudeValue, AltitudeValue}, sensor_world_transform, this);
     }
     else
     {
-      ROS2->ProcessDataFromGNSS(DataStream.GetSensorType(), StreamId, DataStream.GetSensorTransform(), carla::geom::GeoLocation{LatitudeValue, LongitudeValue, AltitudeValue}, this);
+      ROS2->ProcessDataFromGNSS(DataStream.GetSensorType(), StreamId, DataStream.GetSensorTransform(), carla::geom::GeoLocation{LatitudeValue, LongitudeValue, AltitudeValue}, sensor_world_transform, this);
     }
   }
   #endif


### PR DESCRIPTION
Change GNSS ROS2 publishing type to be both
- `Pose`
  - on topic with suffix `/pose`
- `PoseWithCovarianceStamped`
  - on topic with suffix `/pose_with_covariance`

This configuration is what Autoware expects.

> [!NOTE]
> I noticed while implementing this that the lanelet2 map and map in editor have a common origin, so I think that no Additional MGRS offset is required.

Changes the GNSS publishing type permanently, as a future work a configuration or a switch between previously used GNSS and the new one can be implemented.