### PR TITLE
Adjust topics, frame ids, and QoS settings for Autoware

### DIFF
--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -86,7 +86,7 @@ void ROS2::Enable(bool enable) {
   const auto topic_config = [this] {
     TopicConfig config;
     config.domain_id = _domain_id;
-    config.reliability_qos = ReliabilityQoS::BEST_EFFORT;
+    config.reliability_qos = ReliabilityQoS::RELIABLE;
     config.durability_qos = DurabilityQoS::VOLATILE;
     config.history_qos = HistoryQoS::KEEP_LAST;
     config.history_qos_depth = 1;

--- a/LibCarla/source/carla/ros2/publishers/AutowarePublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/AutowarePublisher.cpp
@@ -29,7 +29,7 @@ struct PublisherTraits;
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::VelocityReport> {
   using PubSub = autoware_vehicle_msgs::msg::VelocityReportPubSubType;
-  static constexpr const char* frame_id = "base_line";
+  static constexpr const char* frame_id = "base_link";
   static constexpr const char* topic = "/vehicle/status/velocity_status";
   static constexpr const char* human_name = "Autoware velocity report";
 };
@@ -37,7 +37,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::VelocityReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::SteeringReport> {
   using PubSub = autoware_vehicle_msgs::msg::SteeringReportPubSubType;
-  static constexpr const char* frame_id = "";
+  static constexpr const char* frame_id = "base_link";
   static constexpr const char* topic = "/vehicle/status/steering_status";
   static constexpr const char* human_name = "Autoware steering report";
 };
@@ -45,7 +45,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::SteeringReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::ControlModeReport> {
   using PubSub = autoware_vehicle_msgs::msg::ControlModeReportPubSubType;
-  static constexpr const char* frame_id = "";
+  static constexpr const char* frame_id = "base_link";
   static constexpr const char* topic = "/vehicle/status/control_mode";
   static constexpr const char* human_name = "Autoware control mode report";
 };
@@ -53,7 +53,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::ControlModeReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::GearReport> {
   using PubSub = autoware_vehicle_msgs::msg::GearReportPubSubType;
-  static constexpr const char* frame_id = "";
+  static constexpr const char* frame_id = "base_link";
   static constexpr const char* topic = "/vehicle/status/gear_status";
   static constexpr const char* human_name = "Autoware gear report";
 };
@@ -61,7 +61,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::GearReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::TurnIndicatorsReport> {
   using PubSub = autoware_vehicle_msgs::msg::TurnIndicatorsReportPubSubType;
-  static constexpr const char* frame_id = "";
+  static constexpr const char* frame_id = "base_link";
   static constexpr const char* topic = "/vehicle/status/turn_indicators_status";
   static constexpr const char* human_name = "Autoware turn indicators report";
 };
@@ -69,7 +69,7 @@ struct PublisherTraits<autoware_vehicle_msgs::msg::TurnIndicatorsReport> {
 template <>
 struct PublisherTraits<autoware_vehicle_msgs::msg::HazardLightsReport> {
   using PubSub = autoware_vehicle_msgs::msg::HazardLightsReportPubSubType;
-  static constexpr const char* frame_id = "";
+  static constexpr const char* frame_id = "base_link";
   static constexpr const char* topic = "/vehicle/status/hazard_lights_status";
   static constexpr const char* human_name = "Autoware hazard lights report";
 };

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -24,8 +24,8 @@ def generate_vlp16_blueprint(blueprint_library):
     blueprint.set_attribute("sensor_tick", "0.1")
 
     # ROS settings
-    blueprint.set_attribute("ros_name", "sensor_kit_base_link")  # frame_id
-    blueprint.set_attribute("ros_topic_name", "/sensing/lidar/top/pointcloud_raw")
+    blueprint.set_attribute("ros_name", "velodyne_top")  # frame_id
+    blueprint.set_attribute("ros_topic_name", "/sensing/lidar/top/pointcloud_raw_ex")
 
     return blueprint
 
@@ -45,7 +45,7 @@ def generate_traffic_light_camera_blueprint(blueprint_library):
     blueprint.set_attribute("sensor_tick", "0.1")
 
     # ROS settings
-    blueprint.set_attribute("ros_name", "traffic_light_left_camera/camera_link")  # frame_id
+    blueprint.set_attribute("ros_name", "traffic_light_left_camera/camera_optical_link")  # frame_id
     blueprint.set_attribute("ros_topic_name", "/sensing/camera/traffic_light")
 
     return blueprint
@@ -71,7 +71,7 @@ def generate_gnss_blueprint(blueprint_library):
     blueprint.set_attribute("sensor_tick", "1.0")
 
     # ROS settings
-    blueprint.set_attribute("ros_name", "gnss_link")  # frame_id
+    blueprint.set_attribute("ros_name", "map")  # frame_id
     blueprint.set_attribute("ros_topic_name", "/sensing/gnss")
 
     return blueprint


### PR DESCRIPTION
The following changes are introduced to `autoware_demo.py`:
- topic for LiDAR publishing is changed from `/sensing/lidar/top/pointcloud_raw` to `/sensing/lidar/top/pointcloud_raw_ex`
    - even though AWSIM publishes to both of these topics, only the latter one is subscribed to with the default configuration of Autoware
    - this has been verified by running the stack and analyzing with `ros2cli`
- frame id for LiDAR publishing is changed from `sensor_kit_base_link` to `velodyne_top`
    - this is consistent with https://github.com/tier4/AWSIM/commit/92583dfc63ded0851521e72a279d17173ebb422d
- frame id for camera publishing is changed from `traffic_light_left_camera/camera_link` to `traffic_light_left_camera/camera_optical_link`
    - this is consistent with https://github.com/tier4/AWSIM/commit/92583dfc63ded0851521e72a279d17173ebb422d
 - frame id for GNSS publishing is changed from `gnss` to `map`
     - this is consistent with https://github.com/tier4/AWSIM/commit/92583dfc63ded0851521e72a279d17173ebb422d

Other ROS2 parameters were changed in the code:
- Clock publisher reliability QoS changed to `RELIABLE` from `BEST_EFFORT`
- Autoware status publishers frame_id changed to `base_link` from either `base_line` of empty (changed for all status publishers)
## References

### ROS2 Introspection

When running Autoware, both LiDAR topics were analyzed to check which one is subscribed to within the stack.
As can be seen below, only `/sensing/lidar/top/pointcloud_raw_ex` is used.

```
robotec CarlaAutowareIntegration $ ros2 topic info --verbose /sensing/lidar/top/pointcloud_raw
Unknown topic '/sensing/lidar/top/pointcloud_raw'
robotec CarlaAutowareIntegration $ ros2 topic info --verbose /sensing/lidar/top/pointcloud_raw_ex
Type: sensor_msgs/msg/PointCloud2

Publisher count: 0

Subscription count: 3

Node name: crop_box_filter_self
Node namespace: /sensing/lidar/top
Topic type: sensor_msgs/msg/PointCloud2
Endpoint type: SUBSCRIPTION
GID: 01.10.a6.3b.51.c4.49.9b.fe.13.08.bc.00.00.40.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): UNKNOWN
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: traffic_light_occlusion_predictor
Node namespace: /perception/traffic_light_recognition/traffic_light/classification
Topic type: sensor_msgs/msg/PointCloud2
Endpoint type: SUBSCRIPTION
GID: 01.10.fc.2b.42.54.9f.63.c9.2d.b4.47.00.00.20.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): UNKNOWN
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: traffic_light_occlusion_predictor
Node namespace: /perception/traffic_light_recognition/traffic_light/classification
Topic type: sensor_msgs/msg/PointCloud2
Endpoint type: SUBSCRIPTION
GID: 01.10.fc.2b.42.54.9f.63.c9.2d.b4.47.00.00.24.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: BEST_EFFORT
  History (Depth): UNKNOWN
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```

### Configuration within AWSIM

Latest version of AWSIM v2.0.0 (tier4/AWSIM@92583dfc63ded0851521e72a279d17173ebb422d) has been checked for frame ids of each sensor

#### Frame id for LiDAR

<img width="561" height="436" alt="image" src="https://github.com/user-attachments/assets/04b3445c-0c1a-495e-bb00-a21cbb27fc0b" />

#### Frame id for camera

<img width="554" height="176" alt="image" src="https://github.com/user-attachments/assets/9fb9c66b-9c9f-43b4-9348-0e6832c039ee" />

#### Frame id for GNSS

<img width="559" height="159" alt="image" src="https://github.com/user-attachments/assets/6b95c0cc-03c7-4e58-aab7-6ec300e38ba0" />

#### QoS settings for clock

<img width="558" height="201" alt="image" src="https://github.com/user-attachments/assets/10da9bf4-bf0c-46ee-87d1-b982b32363d7" />

#### Frame id for status publishers

<img width="549" height="415" alt="image" src="https://github.com/user-attachments/assets/e5ec873c-aa5c-4f07-bf6e-36879d81dad1" />
