### PR TITLE
Remove missing test method used in Python API

### DIFF
--- a/PythonAPI/carla/src/World.cpp
+++ b/PythonAPI/carla/src/World.cpp
@@ -340,7 +340,6 @@ void export_world() {
     .def("project_point", CALL_RETURNING_OPTIONAL_3(cc::World, ProjectPoint, cg::Location, cg::Vector3D, float), (arg("location"), arg("direction"), arg("search_distance")=10000.f))
     .def("ground_projection", CALL_RETURNING_OPTIONAL_2(cc::World, GroundProjection, cg::Location, float), (arg("location"), arg("search_distance")=10000.f))
     .def("get_names_of_all_objects", CALL_RETURNING_LIST(cc::World, GetNamesOfAllObjects))
-    .def("get_test_value", &cc::World::GetTestValue)
     .def("get_publish_tf", &cc::World::GetPublishTF)
     .def("set_publish_tf", &cc::World::SetPublishTF, (arg("publish_tf")))
     //.def("get_lightmanager", CONST_CALL_WITHOUT_GIL(cc::World, GetLightManager)) Disabling the light manager as it is not supported in 0.10.0 due to lack of night mode


### PR DESCRIPTION
In commit https://github.com/RobotecAI/carla-autoware/pull/10/commits/c9349d1910249eef2fd3b9f636c49a8ad881c8b1, a test function was removed from `LibCarla/source/carla/client/World.h`.
It was however still being used in `PythonAPI/carla/src/World.cpp`, which caused compilation errors:

```
/home/robotec/Projects/AWF/2025_Q3/CarlaAutowareIntegration/CarlaUE5-copy/PythonAPI/carla/src/World.cpp:343:40: error: no member named 'GetTestValue' in 'carla::client::World'
  343 |     .def("get_test_value", &cc::World::GetTestValue)
      |    
```

It is fixed in this PR.