### PR TITLE
Feature: Time scale

### DIFF
--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -2,6 +2,19 @@ import carla
 import math
 import random
 import argparse
+import time
+
+# Sim rate has to be 100 to make /clock tick with 100Hz (it ticks each frame)
+DESIRED_SIM_RATE = 100
+
+def info(text):
+    print("[INFO]: %s" % text)
+
+def warning(text):
+    print("[WARNING]: %s" % text)
+
+def error(text):
+    print("[ERROR]: %s" % text)
 
 def generate_vlp16_blueprint(blueprint_library):
     """Generates a blueprint for VLP16
@@ -207,6 +220,9 @@ def main():
         '-p', '--port', metavar='P', default=2000, type=int,
         help='TCP port of the host server (default: 2000)')
     argparser.add_argument(
+        '--time_scale', metavar='T', default=1.0, type=float,
+        help='Simulation timescale (default: 1.0)')
+    argparser.add_argument(
         '--follow', action='store_true',
         help='Follow Ego vehicle')
     args = argparser.parse_args()
@@ -224,13 +240,51 @@ def main():
     ego = spawn_ego_with_sensors(world, spawn_point)
     move_spectator(world, ego)
 
-    print('Ego spawned!')
+    info('Ego spawned!')
+    time.sleep(0.05)  # Without this sometimes spectator would not move
 
-    if args.follow:
-        print('Kill this script before stopping simulation!')
-    while args.follow:
-        world.wait_for_tick()
-        move_spectator(world, ego)
+    # Set synchronous mode
+    settings = world.get_settings()
+    settings.synchronous_mode = True
+    settings.fixed_delta_seconds = 1.0 / DESIRED_SIM_RATE
+    world.apply_settings(settings)
+
+    info("Simulation time scale is %f" % args.time_scale)
+
+    warning('Kill this script before stopping simulation!')
+
+    desired_real_time_delta = 1e+9 / DESIRED_SIM_RATE / args.time_scale  # ns
+
+    consecutive_frames = 0
+
+    prev_time = time.time_ns()
+    # Tick world to follow desired time_scale
+    try:
+        while True:
+            current_time = time.time_ns()
+            delta_time = current_time - prev_time
+
+            if delta_time < desired_real_time_delta:
+                consecutive_frames = 0
+                continue
+
+            consecutive_frames += 1
+
+            if consecutive_frames > 200:
+                error("Simulation cannot keep up with the desired time scale!")
+
+            prev_time = current_time
+            world.tick()
+
+            if args.follow:
+                move_spectator(world, ego)
+
+    except KeyboardInterrupt:
+        info("Exiting, restoring asynchronous mode...")
+        # Set asynchronous mode, otherwise simulation will crash
+        settings = world.get_settings()
+        settings.synchronous_mode = False
+        world.apply_settings(settings)
 
 if __name__ == '__main__':
     main()

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -253,33 +253,34 @@ def main():
 
     warning('Kill this script before stopping simulation!')
 
-    desired_real_time_delta = 1e+9 / DESIRED_SIM_RATE / args.time_scale  # ns
+    frame_count = 0
 
-    consecutive_frames = 0
-
-    prev_time = time.time_ns()
+    start_time = time.time()
+    last_behind_error_time = start_time
     # Tick world to follow desired time_scale
     try:
         while True:
-            current_time = time.time_ns()
-            delta_time = current_time - prev_time
+            current_time = time.time()
+            real_time_passed = current_time - start_time
+            sim_time_passed = real_time_passed * args.time_scale
+            desired_frame_count = math.floor(sim_time_passed * DESIRED_SIM_RATE)
 
-            if delta_time < desired_real_time_delta:
-                consecutive_frames = 0
+            if desired_frame_count <= frame_count:
                 continue
 
-            consecutive_frames += 1
+            frame_behind_count = max(desired_frame_count - frame_count, 0)
+            if (frame_behind_count > 10) and \
+                (current_time > last_behind_error_time + 2.0):  # Error every 2 seconds
+                    last_behind_error_time = current_time
+                    error(f'Simulation cannot keep up with the desired time scale!!! ({frame_behind_count} frames behind)')
 
-            if consecutive_frames > 200:
-                error("Simulation cannot keep up with the desired time scale!")
-
-            prev_time = current_time
             world.tick()
+            frame_count += 1
 
             if args.follow:
                 move_spectator(world, ego)
 
-    except KeyboardInterrupt:
+    except:  # KeyboardInterrupt:
         info("Exiting, restoring asynchronous mode...")
         # Set asynchronous mode, otherwise simulation will crash
         settings = world.get_settings()


### PR DESCRIPTION
Adds support for simulation timescale.

Simulation is run in synchronous mode (instead in asynchronous as before).
It is run in fixed time-step of  $\frac{1}{100} \text{s}$ to guarantee the clock ticking at 100Hz in simulation time.

The simulation is ticked to keep with running $100 \times \text{timescale}$ frames each real time second.

If the machine is not powerful enough, the simulation will tick as fast as possible and lag behind displaying error.

The timescale can be set using argument `--time_scale` (e.g. `python3 autoware_demo.py --time_scale 0.5`)

> [!IMPORTANT]
> This PR also fixes weird vehicle behavior, stuttering and torn animations.
> These seem to have been caused by using variable step-time.
> Using fixed time-step not only guarantees clock ticking and 100Hz in sim time but also fixes the above issues.