### PR TITLE
Add Rider files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ CMakeSettings.json
 .clangd
 
 Help.md
+
+# Ignore Rider IDE files
+.idea/
+Unreal/CarlaUnreal/Plugins/Developer/RiderLink/
+Unreal/CarlaUnreal/Plugins/RiderLink/


### PR DESCRIPTION
## About
Add Rider IDE files to gitignore:
- `.idea/`
- `RiderLink` - plugin for Unreal Engine 