### PR TITLE
Fix: Dark camera output

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorBlueprintFunctionLibrary.cpp
@@ -23,6 +23,7 @@
 class FActorDefinitionValidator
 {
 public:
+
   /// Iterate all actor definitions and their properties and display messages on
   /// error.
   bool AreValid(const TArray<FActorDefinition> &ActorDefinitions)
@@ -39,10 +40,11 @@ public:
   }
 
 private:
+
   /// If @a Predicate is false, print an error message. If possible the message
   /// is printed to the editor window.
-  template <typename T, typename... ARGS>
-  bool OnScreenAssert(bool Predicate, const T &Format, ARGS &&...Args) const
+  template <typename T, typename ... ARGS>
+  bool OnScreenAssert(bool Predicate, const T &Format, ARGS && ... Args) const
   {
     if (!Predicate)
     {
@@ -52,7 +54,7 @@ private:
         Message += String;
       }
       Message += TEXT(" ");
-      Message += FString::Printf(Format, std::forward<ARGS>(Args)...);
+      Message += FString::Printf(Format, std::forward<ARGS>(Args) ...);
 
       UE_LOG(LogCarla, Error, TEXT("%s"), *Message);
 #if WITH_EDITOR
@@ -97,8 +99,7 @@ private:
   template <typename T>
   bool AreValid(const FString &Type, const TArray<T> &Array)
   {
-    return ForEach(Type, Array, [this](const auto &Item)
-                   { return IsValid(Item); });
+    return ForEach(Type, Array, [this](const auto &Item) { return IsValid(Item); });
   }
 
   bool IsIdValid(const FString &Id)
@@ -127,36 +128,40 @@ private:
 
   bool IsValid(const FActorVariation &Variation)
   {
-    return IsIdValid(Variation.Id) &&
-           IsValid(Variation.Type) &&
-           OnScreenAssert(Variation.RecommendedValues.Num() > 0, TEXT("Recommended values cannot be empty")) &&
-           ForEach(TEXT("Recommended Value"), Variation.RecommendedValues, [&](auto &Value)
-                   { return ValueIsValid(Variation.Type, Value); });
+    return
+      IsIdValid(Variation.Id) &&
+      IsValid(Variation.Type) &&
+      OnScreenAssert(Variation.RecommendedValues.Num() > 0, TEXT("Recommended values cannot be empty")) &&
+      ForEach(TEXT("Recommended Value"), Variation.RecommendedValues, [&](auto &Value) {
+      return ValueIsValid(Variation.Type, Value);
+    });
   }
 
   bool IsValid(const FActorAttribute &Attribute)
   {
-    return IsIdValid(Attribute.Id) &&
-           IsValid(Attribute.Type) &&
-           ValueIsValid(Attribute.Type, Attribute.Value);
+    return
+      IsIdValid(Attribute.Id) &&
+      IsValid(Attribute.Type) &&
+      ValueIsValid(Attribute.Type, Attribute.Value);
   }
 
   bool IsValid(const FActorDefinition &ActorDefinition)
   {
     /// @todo Validate Class and make sure IDs are not repeated.
-    return IsIdValid(ActorDefinition.Id) &&
-           AreTagsValid(ActorDefinition.Tags) &&
-           AreValid(TEXT("Variation"), ActorDefinition.Variations) &&
-           AreValid(TEXT("Attribute"), ActorDefinition.Attributes);
+    return
+      IsIdValid(ActorDefinition.Id) &&
+      AreTagsValid(ActorDefinition.Tags) &&
+      AreValid(TEXT("Variation"), ActorDefinition.Variations) &&
+      AreValid(TEXT("Attribute"), ActorDefinition.Attributes);
   }
 
   FScopedStack<FString> Stack;
 };
 
-template <typename... ARGS>
-static FString JoinStrings(const FString &Separator, ARGS &&...Args)
+template <typename ... ARGS>
+static FString JoinStrings(const FString &Separator, ARGS && ... Args)
 {
-  return FString::Join(TArray<FString>{std::forward<ARGS>(Args)...}, *Separator);
+  return FString::Join(TArray<FString>{std::forward<ARGS>(Args) ...}, *Separator);
 }
 
 static FString ColorToFString(const FColor &Color)
@@ -197,17 +202,17 @@ bool UActorBlueprintFunctionLibrary::CheckActorDefinitions(const TArray<FActorDe
 /// -- Helpers to create actor definitions -------------------------------------
 /// ============================================================================
 
-template <typename... TStrs>
-static void FillIdAndTags(FActorDefinition &Def, TStrs &&...Strings)
+template <typename ... TStrs>
+static void FillIdAndTags(FActorDefinition &Def, TStrs && ... Strings)
 {
-  Def.Id = JoinStrings(TEXT("."), std::forward<TStrs>(Strings)...).ToLower();
-  Def.Tags = JoinStrings(TEXT(","), std::forward<TStrs>(Strings)...).ToLower();
+  Def.Id = JoinStrings(TEXT("."), std::forward<TStrs>(Strings) ...).ToLower();
+  Def.Tags = JoinStrings(TEXT(","), std::forward<TStrs>(Strings) ...).ToLower();
 
   // each actor gets an actor role name attribute (empty by default)
   FActorVariation ActorRole;
   ActorRole.Id = TEXT("role_name");
   ActorRole.Type = EActorAttributeType::String;
-  ActorRole.RecommendedValues = {TEXT("default")};
+  ActorRole.RecommendedValues = { TEXT("default") };
   ActorRole.bRestrictToRecommended = false;
   Def.Variations.Emplace(ActorRole);
 
@@ -235,7 +240,7 @@ static void AddRecommendedValuesForActorRoleName(
     FActorDefinition &Definition,
     TArray<FString> &&RecommendedValues)
 {
-  for (auto &&ActorVariation : Definition.Variations)
+  for (auto &&ActorVariation: Definition.Variations)
   {
     if (ActorVariation.Id == "role_name")
     {
@@ -247,7 +252,8 @@ static void AddRecommendedValuesForActorRoleName(
 
 static void AddRecommendedValuesForSensorRoleNames(FActorDefinition &Definition)
 {
-  AddRecommendedValuesForActorRoleName(Definition, {TEXT("front"), TEXT("back"), TEXT("left"), TEXT("right"), TEXT("front_left"), TEXT("front_right"), TEXT("back_left"), TEXT("back_right")});
+  AddRecommendedValuesForActorRoleName(Definition, {TEXT("front"), TEXT("back"), TEXT("left"), TEXT(
+      "right"), TEXT("front_left"), TEXT("front_right"), TEXT("back_left"), TEXT("back_right")});
 }
 
 static void AddVariationsForSensor(FActorDefinition &Def)
@@ -256,7 +262,7 @@ static void AddVariationsForSensor(FActorDefinition &Def)
 
   Tick.Id = TEXT("sensor_tick");
   Tick.Type = EActorAttributeType::Float;
-  Tick.RecommendedValues = {TEXT("0.0")};
+  Tick.RecommendedValues = { TEXT("0.0") };
   Tick.bRestrictToRecommended = false;
 
   Def.Variations.Emplace(Tick);
@@ -268,7 +274,7 @@ static void AddVariationsForTrigger(FActorDefinition &Def)
   FActorVariation Friction;
   Friction.Id = FString("friction");
   Friction.Type = EActorAttributeType::Float;
-  Friction.RecommendedValues = {TEXT("3.5f")};
+  Friction.RecommendedValues = { TEXT("3.5f") };
   Friction.bRestrictToRecommended = false;
   Def.Variations.Emplace(Friction);
 
@@ -282,7 +288,7 @@ static void AddVariationsForTrigger(FActorDefinition &Def)
 
     ExtentCoordinate.Id = JoinStrings(TEXT("_"), Extent, Coordinate);
     ExtentCoordinate.Type = EActorAttributeType::Float;
-    ExtentCoordinate.RecommendedValues = {TEXT("1.0f")};
+    ExtentCoordinate.RecommendedValues = { TEXT("1.0f") };
     ExtentCoordinate.bRestrictToRecommended = false;
 
     Def.Variations.Emplace(ExtentCoordinate);
@@ -333,129 +339,117 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
   FActorVariation FOV;
   FOV.Id = TEXT("fov");
   FOV.Type = EActorAttributeType::Float;
-  FOV.RecommendedValues = {TEXT("90.0")};
+  FOV.RecommendedValues = { TEXT("90.0") };
   FOV.bRestrictToRecommended = false;
 
   // Resolution
   FActorVariation ResX;
   ResX.Id = TEXT("image_size_x");
   ResX.Type = EActorAttributeType::Int;
-  ResX.RecommendedValues = {TEXT("800")};
+  ResX.RecommendedValues = { TEXT("800") };
   ResX.bRestrictToRecommended = false;
 
   FActorVariation ResY;
   ResY.Id = TEXT("image_size_y");
   ResY.Type = EActorAttributeType::Int;
-  ResY.RecommendedValues = {TEXT("600")};
+  ResY.RecommendedValues = { TEXT("600") };
   ResY.bRestrictToRecommended = false;
 
   // Lens parameters
   FActorVariation LensCircleFalloff;
   LensCircleFalloff.Id = TEXT("lens_circle_falloff");
   LensCircleFalloff.Type = EActorAttributeType::Float;
-  LensCircleFalloff.RecommendedValues = {TEXT("5.0")};
+  LensCircleFalloff.RecommendedValues = { TEXT("5.0") };
   LensCircleFalloff.bRestrictToRecommended = false;
 
   FActorVariation LensCircleMultiplier;
   LensCircleMultiplier.Id = TEXT("lens_circle_multiplier");
   LensCircleMultiplier.Type = EActorAttributeType::Float;
-  LensCircleMultiplier.RecommendedValues = {TEXT("0.0")};
+  LensCircleMultiplier.RecommendedValues = { TEXT("0.0") };
   LensCircleMultiplier.bRestrictToRecommended = false;
 
   FActorVariation LensK;
   LensK.Id = TEXT("lens_k");
   LensK.Type = EActorAttributeType::Float;
-  LensK.RecommendedValues = {TEXT("-1.0")};
+  LensK.RecommendedValues = { TEXT("-1.0") };
   LensK.bRestrictToRecommended = false;
 
   FActorVariation LensKcube;
   LensKcube.Id = TEXT("lens_kcube");
   LensKcube.Type = EActorAttributeType::Float;
-  LensKcube.RecommendedValues = {TEXT("0.0")};
+  LensKcube.RecommendedValues = { TEXT("0.0") };
   LensKcube.bRestrictToRecommended = false;
 
   FActorVariation LensXSize;
   LensXSize.Id = TEXT("lens_x_size");
   LensXSize.Type = EActorAttributeType::Float;
-  LensXSize.RecommendedValues = {TEXT("0.08")};
+  LensXSize.RecommendedValues = { TEXT("0.08") };
   LensXSize.bRestrictToRecommended = false;
 
   FActorVariation LensYSize;
   LensYSize.Id = TEXT("lens_y_size");
   LensYSize.Type = EActorAttributeType::Float;
-  LensYSize.RecommendedValues = {TEXT("0.08")};
+  LensYSize.RecommendedValues = { TEXT("0.08") };
   LensYSize.bRestrictToRecommended = false;
 
-  Definition.Variations.Append({ResX,
-                                ResY,
-                                FOV,
-                                LensCircleFalloff,
-                                LensCircleMultiplier,
-                                LensK,
-                                LensKcube,
-                                LensXSize,
-                                LensYSize});
+  Definition.Variations.Append({
+      ResX,
+      ResY,
+      FOV,
+      LensCircleFalloff,
+      LensCircleMultiplier,
+      LensK,
+      LensKcube,
+      LensXSize,
+      LensYSize});
 
   if (bEnableModifyingPostProcessEffects)
   {
     FActorVariation PostProccess;
     PostProccess.Id = TEXT("enable_postprocess_effects");
     PostProccess.Type = EActorAttributeType::Bool;
-    PostProccess.RecommendedValues = {TEXT("true")};
+    PostProccess.RecommendedValues = { TEXT("true") };
     PostProccess.bRestrictToRecommended = false;
 
     // Gamma
     FActorVariation Gamma;
     Gamma.Id = TEXT("gamma");
     Gamma.Type = EActorAttributeType::Float;
-    Gamma.RecommendedValues = {TEXT("1.2")};
+    Gamma.RecommendedValues = { TEXT("1.2") };
     Gamma.bRestrictToRecommended = false;
 
     // Motion Blur
     FActorVariation MBIntesity;
     MBIntesity.Id = TEXT("motion_blur_intensity");
     MBIntesity.Type = EActorAttributeType::Float;
-    MBIntesity.RecommendedValues = {TEXT("0.5")};
+    MBIntesity.RecommendedValues = { TEXT("0.5") };
     MBIntesity.bRestrictToRecommended = false;
 
     FActorVariation MBMaxDistortion;
     MBMaxDistortion.Id = TEXT("motion_blur_max_distortion");
     MBMaxDistortion.Type = EActorAttributeType::Float;
-    MBMaxDistortion.RecommendedValues = {TEXT("5.0")};
+    MBMaxDistortion.RecommendedValues = { TEXT("5.0") };
     MBMaxDistortion.bRestrictToRecommended = false;
 
     FActorVariation MBMinObjectScreenSize;
     MBMinObjectScreenSize.Id = TEXT("motion_blur_min_object_screen_size");
     MBMinObjectScreenSize.Type = EActorAttributeType::Float;
-    MBMinObjectScreenSize.RecommendedValues = {TEXT("0.0")};
+    MBMinObjectScreenSize.RecommendedValues = { TEXT("0.0") };
     MBMinObjectScreenSize.bRestrictToRecommended = false;
 
     // Lens Flare
     FActorVariation LensFlareIntensity;
     LensFlareIntensity.Id = TEXT("lens_flare_intensity");
     LensFlareIntensity.Type = EActorAttributeType::Float;
-    LensFlareIntensity.RecommendedValues = {TEXT("0.01")};
+    LensFlareIntensity.RecommendedValues = { TEXT("0.2") };
     LensFlareIntensity.bRestrictToRecommended = false;
 
     // Bloom
-    FActorVariation BloomMethod;
-    BloomMethod.Id = TEXT("bloom_method");
-    BloomMethod.Type = EActorAttributeType::String;
-    BloomMethod.RecommendedValues = {TEXT("standard"), TEXT("convolution")};
-    BloomMethod.bRestrictToRecommended = false;
-
     FActorVariation BloomIntensity;
     BloomIntensity.Id = TEXT("bloom_intensity");
     BloomIntensity.Type = EActorAttributeType::Float;
-    BloomIntensity.RecommendedValues = {TEXT("0.5")};
+    BloomIntensity.RecommendedValues = { TEXT("0.0") };
     BloomIntensity.bRestrictToRecommended = false;
-
-    // TO DO RIGHT, ASK AARON
-    /*FActorVariation BloomConvolutionTexture;
-    BloomConvolutionTexture.Id = TEXT("bloom_convolution_texture");
-    BloomConvolutionTexture.Type = EActorAttributeType::Float; //¿?
-    BloomConvolutionTexture.RecommendedValues = {TEXT("0.5")};
-    BloomConvolutionTexture.bRestrictToRecommended = false;*/
 
     // More info at:
     // https://docs.unrealengine.com/en-US/Engine/Rendering/PostProcessEffects/AutomaticExposure/index.html
@@ -466,21 +460,8 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation ExposureMode;
     ExposureMode.Id = TEXT("exposure_mode");
     ExposureMode.Type = EActorAttributeType::String;
-    ExposureMode.RecommendedValues = {TEXT("histogram"), TEXT("manual")};
+    ExposureMode.RecommendedValues = { TEXT("histogram"), TEXT("manual") };
     ExposureMode.bRestrictToRecommended = true;
-
-    // Dirt Mask
-    FActorVariation DirtMaskIntensity;
-    DirtMaskIntensity.Id = TEXT("dirt_mask_intensity");
-    DirtMaskIntensity.Type = EActorAttributeType::Float;
-    DirtMaskIntensity.RecommendedValues = {TEXT("50.0")};
-    DirtMaskIntensity.bRestrictToRecommended = false;
-
-    /*FActorVariation DirtMaskTexture;
-    DirtMaskTexture.Id = TEXT("dirt_mask_texture");
-    DirtMaskTexture.Type = EActorAttributeType::Float; // ¿?
-    DirtMaskTexture.RecommendedValues = {TEXT("0.5")};
-    DirtMaskTexture.bRestrictToRecommended = false;*/
 
     // Logarithmic adjustment for the exposure. Only used if a tonemapper is
     // specified.
@@ -492,19 +473,19 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation ExposureCompensation;
     ExposureCompensation.Id = TEXT("exposure_compensation");
     ExposureCompensation.Type = EActorAttributeType::Float;
-    ExposureCompensation.RecommendedValues = {TEXT("0.5")};
+    ExposureCompensation.RecommendedValues = { TEXT("1.5") };
     ExposureCompensation.bRestrictToRecommended = false;
 
     FActorVariation HighlightContrastScaleVariation;
     HighlightContrastScaleVariation.Id = TEXT("highlight_contrast_scale");
     HighlightContrastScaleVariation.Type = EActorAttributeType::Float;
-    HighlightContrastScaleVariation.RecommendedValues = {TEXT("1.0")};
+    HighlightContrastScaleVariation.RecommendedValues = { TEXT("0.7") };
     HighlightContrastScaleVariation.bRestrictToRecommended = false;
 
     FActorVariation ShadowContrastScaleVariation;
     ShadowContrastScaleVariation.Id = TEXT("shadow_constrast_scale");
     ShadowContrastScaleVariation.Type = EActorAttributeType::Float;
-    ShadowContrastScaleVariation.RecommendedValues = {TEXT("0.6")};
+    ShadowContrastScaleVariation.RecommendedValues = { TEXT("0.65") };
     ShadowContrastScaleVariation.bRestrictToRecommended = false;
 
     // - Manual ------------------------------------------------
@@ -516,14 +497,14 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation ShutterSpeed; // (1/t)
     ShutterSpeed.Id = TEXT("shutter_speed");
     ShutterSpeed.Type = EActorAttributeType::Float;
-    ShutterSpeed.RecommendedValues = {TEXT("60.0")};
+    ShutterSpeed.RecommendedValues = { TEXT("15.0") };
     ShutterSpeed.bRestrictToRecommended = false;
 
     // The camera sensor sensitivity.
     FActorVariation ISO; // S
     ISO.Id = TEXT("iso");
     ISO.Type = EActorAttributeType::Float;
-    ISO.RecommendedValues = {TEXT("100.0")};
+    ISO.RecommendedValues = { TEXT("300000.0") };
     ISO.bRestrictToRecommended = false;
 
     // Defines the size of the opening for the camera lens.
@@ -531,7 +512,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation Aperture; // N
     Aperture.Id = TEXT("fstop");
     Aperture.Type = EActorAttributeType::Float;
-    Aperture.RecommendedValues = {TEXT("8.0")};
+    Aperture.RecommendedValues = { TEXT("9.8") };
     Aperture.bRestrictToRecommended = false;
 
     // Defines the opening of the camera lens, Aperture is 1.0/fstop,
@@ -540,7 +521,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation MaxAperture;
     MaxAperture.Id = TEXT("min_fstop");
     MaxAperture.Type = EActorAttributeType::Float;
-    MaxAperture.RecommendedValues = {TEXT("1.2")};
+    MaxAperture.RecommendedValues = { TEXT("1.2") };
     MaxAperture.bRestrictToRecommended = false;
 
     // Defines the number of blades of the diaphragm within the
@@ -548,8 +529,9 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation BladeCount;
     BladeCount.Id = TEXT("blade_count");
     BladeCount.Type = EActorAttributeType::Int;
-    BladeCount.RecommendedValues = {TEXT("5")};
+    BladeCount.RecommendedValues = { TEXT("5") };
     BladeCount.bRestrictToRecommended = false;
+
 
     // - Histogram ---------------------------------------------
 
@@ -558,7 +540,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation ExposureMinBright;
     ExposureMinBright.Id = TEXT("exposure_min_bright");
     ExposureMinBright.Type = EActorAttributeType::Float;
-    ExposureMinBright.RecommendedValues = {TEXT("0.0")};
+    ExposureMinBright.RecommendedValues = { TEXT("0.0") };
     ExposureMinBright.bRestrictToRecommended = false;
 
     // The maximum brightness for auto exposure that limits the upper
@@ -566,7 +548,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation ExposureMaxBright;
     ExposureMaxBright.Id = TEXT("exposure_max_bright");
     ExposureMaxBright.Type = EActorAttributeType::Float;
-    ExposureMaxBright.RecommendedValues = {TEXT("20.0")};
+    ExposureMaxBright.RecommendedValues = { TEXT("20.0") };
     ExposureMaxBright.bRestrictToRecommended = false;
 
     // The speed at which the adaptation occurs from a dark environment
@@ -574,7 +556,7 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation ExposureSpeedUp;
     ExposureSpeedUp.Id = TEXT("exposure_speed_up");
     ExposureSpeedUp.Type = EActorAttributeType::Float;
-    ExposureSpeedUp.RecommendedValues = {TEXT("3.0")};
+    ExposureSpeedUp.RecommendedValues = { TEXT("3.0") };
     ExposureSpeedUp.bRestrictToRecommended = false;
 
     // The speed at which the adaptation occurs from a bright environment
@@ -582,21 +564,21 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation ExposureSpeedDown;
     ExposureSpeedDown.Id = TEXT("exposure_speed_down");
     ExposureSpeedDown.Type = EActorAttributeType::Float;
-    ExposureSpeedDown.RecommendedValues = {TEXT("1.0")};
+    ExposureSpeedDown.RecommendedValues = { TEXT("1.0") };
     ExposureSpeedDown.bRestrictToRecommended = false;
 
     // Calibration constant for 18% Albedo.
     FActorVariation CalibrationConstant;
     CalibrationConstant.Id = TEXT("calibration_constant");
     CalibrationConstant.Type = EActorAttributeType::Float;
-    CalibrationConstant.RecommendedValues = {TEXT("16.0")};
+    CalibrationConstant.RecommendedValues = { TEXT("16.0") };
     CalibrationConstant.bRestrictToRecommended = false;
 
     // Sensor width to assume in mm
     FActorVariation SensorWidth;
     SensorWidth.Id = TEXT("sensor_width");
     SensorWidth.Type = EActorAttributeType::Float;
-    SensorWidth.RecommendedValues = {TEXT("24.576000")};
+    SensorWidth.RecommendedValues = { TEXT("24.576000") };
     SensorWidth.bRestrictToRecommended = false;
 
     // Distance in which the Depth of Field effect should be sharp,
@@ -604,21 +586,21 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation FocalDistance;
     FocalDistance.Id = TEXT("focal_distance");
     FocalDistance.Type = EActorAttributeType::Float;
-    FocalDistance.RecommendedValues = {TEXT("250.0")};
+    FocalDistance.RecommendedValues = { TEXT("250.0") };
     FocalDistance.bRestrictToRecommended = false;
 
     // Depth blur km for 50%
     FActorVariation DepthBlurAmount;
     DepthBlurAmount.Id = TEXT("blur_amount");
     DepthBlurAmount.Type = EActorAttributeType::Float;
-    DepthBlurAmount.RecommendedValues = {TEXT("1.0")};
+    DepthBlurAmount.RecommendedValues = { TEXT("1.0") };
     DepthBlurAmount.bRestrictToRecommended = false;
 
     // Depth blur radius in pixels at 1920x
     FActorVariation DepthBlurRadius;
     DepthBlurRadius.Id = TEXT("blur_radius");
     DepthBlurRadius.Type = EActorAttributeType::Float;
-    DepthBlurRadius.RecommendedValues = {TEXT("0.0")};
+    DepthBlurRadius.RecommendedValues = { TEXT("0.0") };
     DepthBlurRadius.bRestrictToRecommended = false;
 
     // - Tonemapper Settings -----------------------------------
@@ -627,222 +609,143 @@ void UActorBlueprintFunctionLibrary::MakeCameraDefinition(
     FActorVariation FilmSlope;
     FilmSlope.Id = TEXT("slope");
     FilmSlope.Type = EActorAttributeType::Float;
-    FilmSlope.RecommendedValues = {TEXT("0.7")};
+    FilmSlope.RecommendedValues = { TEXT("0.88") };
     FilmSlope.bRestrictToRecommended = false;
 
     FActorVariation FilmToe;
     FilmToe.Id = TEXT("toe");
     FilmToe.Type = EActorAttributeType::Float;
-    FilmToe.RecommendedValues = {TEXT("0.25")};
+    FilmToe.RecommendedValues = { TEXT("0.55") };
     FilmToe.bRestrictToRecommended = false;
 
     FActorVariation FilmShoulder;
     FilmShoulder.Id = TEXT("shoulder");
     FilmShoulder.Type = EActorAttributeType::Float;
-    FilmShoulder.RecommendedValues = {TEXT("0.26")};
+    FilmShoulder.RecommendedValues = { TEXT("0.26") };
     FilmShoulder.bRestrictToRecommended = false;
 
     FActorVariation FilmBlackClip;
     FilmBlackClip.Id = TEXT("black_clip");
     FilmBlackClip.Type = EActorAttributeType::Float;
-    FilmBlackClip.RecommendedValues = {TEXT("0.0")};
+    FilmBlackClip.RecommendedValues = { TEXT("0.0") };
     FilmBlackClip.bRestrictToRecommended = false;
 
     FActorVariation FilmWhiteClip;
     FilmWhiteClip.Id = TEXT("white_clip");
     FilmWhiteClip.Type = EActorAttributeType::Float;
-    FilmWhiteClip.RecommendedValues = {TEXT("0.04")};
+    FilmWhiteClip.RecommendedValues = { TEXT("0.04") };
     FilmWhiteClip.bRestrictToRecommended = false;
-
-    // Ambient Occlusion
-    FActorVariation AmbientOcclusionIntensity;
-    AmbientOcclusionIntensity.Id = TEXT("ambient_occlusion_intensity");
-    AmbientOcclusionIntensity.Type = EActorAttributeType::Float;
-    AmbientOcclusionIntensity.RecommendedValues = {TEXT("1.0")};
-    AmbientOcclusionIntensity.bRestrictToRecommended = false;
-
-    FActorVariation AmbientOcclusionRadius;
-    AmbientOcclusionRadius.Id = TEXT("ambient_occlusion_radius");
-    AmbientOcclusionRadius.Type = EActorAttributeType::Float;
-    AmbientOcclusionRadius.RecommendedValues = {TEXT("40.0")};
-    AmbientOcclusionRadius.bRestrictToRecommended = false;
-
-    // Film Grain
-    FActorVariation FilmGrainIntensity;
-    FilmGrainIntensity.Id = TEXT("film_grain_intensity");
-    FilmGrainIntensity.Type = EActorAttributeType::Float;
-    FilmGrainIntensity.RecommendedValues = {TEXT("0.1")};
-    FilmGrainIntensity.bRestrictToRecommended = false;
-
-    // Local Exposure
-    FActorVariation DetailStrength;
-    DetailStrength.Id = TEXT("detail_strength");
-    DetailStrength.Type = EActorAttributeType::Float;
-    DetailStrength.RecommendedValues = {TEXT("1.2")};
-    DetailStrength.bRestrictToRecommended = false;
-
-    FActorVariation LocalExposureMethod;
-    LocalExposureMethod.Id = TEXT("local_exposure_method");
-    LocalExposureMethod.Type = EActorAttributeType::String;
-    LocalExposureMethod.RecommendedValues = {TEXT("bilateral"), TEXT("fusion")};
-    LocalExposureMethod.bRestrictToRecommended = false;
 
     // Color
     FActorVariation Temperature;
     Temperature.Id = TEXT("temp");
     Temperature.Type = EActorAttributeType::Float;
-    Temperature.RecommendedValues = {TEXT("6600.0")};
+    Temperature.RecommendedValues = { TEXT("7700.0") };
     Temperature.bRestrictToRecommended = false;
 
     FActorVariation Tint;
     Tint.Id = TEXT("tint");
     Tint.Type = EActorAttributeType::Float;
-    Tint.RecommendedValues = {TEXT("-0.05")};
+    Tint.RecommendedValues = { TEXT("-0.15") };
     Tint.bRestrictToRecommended = false;
 
     FActorVariation ChromaticIntensity;
     ChromaticIntensity.Id = TEXT("chromatic_aberration_intensity");
     ChromaticIntensity.Type = EActorAttributeType::Float;
-    ChromaticIntensity.RecommendedValues = {TEXT("0.15")};
+    ChromaticIntensity.RecommendedValues = { TEXT("0.15") };
     ChromaticIntensity.bRestrictToRecommended = false;
 
     FActorVariation ChromaticOffset;
     ChromaticOffset.Id = TEXT("chromatic_aberration_offset");
     ChromaticOffset.Type = EActorAttributeType::Float;
-    ChromaticOffset.RecommendedValues = {TEXT("0.0")};
+    ChromaticOffset.RecommendedValues = { TEXT("0.0") };
     ChromaticOffset.bRestrictToRecommended = false;
-
-    FActorVariation BlueCorrection;
-    BlueCorrection.Id = TEXT("blue_correction");
-    BlueCorrection.Type = EActorAttributeType::Float;
-    BlueCorrection.RecommendedValues = {TEXT("0.6")};
-    BlueCorrection.bRestrictToRecommended = false;
 
     FActorVariation ColorSaturation;
     ColorSaturation.Id = TEXT("color_saturation");
     ColorSaturation.Type = EActorAttributeType::RGBColor;
-    ColorSaturation.RecommendedValues = {ColorToFString(FLinearColor(0.696528f, 0.802778f, 0.850000f, 0.700000f).ToFColorSRGB())};
+    ColorSaturation.RecommendedValues = { ColorToFString(FLinearColor(0.5f, 0.5f, 0.5f, 1.0f).ToFColorSRGB()) };
     ColorSaturation.bRestrictToRecommended = false;
-
-    FActorVariation ColorSaturationMidtones;
-    ColorSaturationMidtones.Id = TEXT("color_saturation_midtones");
-    ColorSaturationMidtones.Type = EActorAttributeType::RGBColor;
-    ColorSaturationMidtones.RecommendedValues = {ColorToFString(FLinearColor(0.8f, 1.4f, 0.9f, 1.00000f).ToFColorSRGB())};
-    ColorSaturationMidtones.bRestrictToRecommended = false;
-
-    FActorVariation ColorSaturationHighlights;
-    ColorSaturationHighlights.Id = TEXT("color_saturation_highlights");
-    ColorSaturationHighlights.Type = EActorAttributeType::RGBColor;
-    ColorSaturationHighlights.RecommendedValues = {ColorToFString(FLinearColor(1.0f, 1.0f, 1.0f, 1.0f).ToFColorSRGB())};
-    ColorSaturationHighlights.bRestrictToRecommended = false;
 
     FActorVariation ColorContrast;
     ColorContrast.Id = TEXT("color_contrast");
-    ColorContrast.Type = EActorAttributeType::RGBColor;
-    ColorContrast.RecommendedValues = {ColorToFString(FLinearColor(0.9f, 0.9f, 0.9f).ToFColorSRGB())};
+    ColorContrast.Type = EActorAttributeType::Vector;
+    ColorContrast.RecommendedValues = { VectorToFString(FVector(1.6f, 1.6f, 1.6f)) };
     ColorContrast.bRestrictToRecommended = false;
-
-    FActorVariation ColorContrastMidtones;
-    ColorContrastMidtones.Id = TEXT("color_contrast_midtones");
-    ColorContrastMidtones.Type = EActorAttributeType::RGBColor;
-    ColorContrastMidtones.RecommendedValues = {ColorToFString(FLinearColor(1.2f, 1.2f, 1.2f).ToFColorSRGB())};
-    ColorContrastMidtones.bRestrictToRecommended = false;
-
-    FActorVariation ColorContrastHighlights;
-    ColorContrastHighlights.Id = TEXT("color_contrast_highlights");
-    ColorContrastHighlights.Type = EActorAttributeType::RGBColor;
-    ColorContrastHighlights.RecommendedValues = {ColorToFString(FLinearColor(1.5f, 1.5f, 1.5f).ToFColorSRGB())};
-    ColorContrastHighlights.bRestrictToRecommended = false;
-
-    FActorVariation ColorGain;
-    ColorGain.Id = TEXT("color-gain");
-    ColorGain.Type = EActorAttributeType::RGBColor;
-    ColorGain.RecommendedValues = {ColorToFString(FLinearColor(0.9f, 0.9f, 0.9f).ToFColorSRGB())};
-    ColorGain.bRestrictToRecommended = false;
 
     FActorVariation ColorGamma;
     ColorGamma.Id = TEXT("color_gamma");
-    ColorGamma.Type = EActorAttributeType::RGBColor;
-    ColorGamma.RecommendedValues = {ColorToFString(FLinearColor(1.1f, 1.1f, 1.1f).ToFColorSRGB())};
+    ColorGamma.Type = EActorAttributeType::Vector;
+    ColorGamma.RecommendedValues = { VectorToFString(FVector(1.2f, 1.2f, 1.2f)) };
     ColorGamma.bRestrictToRecommended = false;
 
     FActorVariation HighlightsGamma;
     HighlightsGamma.Id = TEXT("highlights_gamma");
     HighlightsGamma.Type = EActorAttributeType::RGBColor;
-    HighlightsGamma.RecommendedValues = {ColorToFString(FLinearColor(1.0f, 1.0f, 1.0f).ToFColorSRGB())};
+    HighlightsGamma.RecommendedValues = { ColorToFString(FLinearColor(0.5f, 0.5f, 0.5f).ToFColorSRGB()) };
     HighlightsGamma.bRestrictToRecommended = false;
 
     FActorVariation ToneCurveAmount;
     ToneCurveAmount.Id = TEXT("tone_curve_amount");
     ToneCurveAmount.Type = EActorAttributeType::Float;
-    ToneCurveAmount.RecommendedValues = {TEXT("1.0")};
+    ToneCurveAmount.RecommendedValues = { TEXT("1.0") };
     ToneCurveAmount.bRestrictToRecommended = false;
 
     FActorVariation SceneColorTint;
     SceneColorTint.Id = TEXT("scene_color_tint");
     SceneColorTint.Type = EActorAttributeType::RGBColor;
-    SceneColorTint.RecommendedValues = {ColorToFString(FLinearColor(0.921569f, 0.972549f, 0.796079f).ToFColorSRGB())};
+    SceneColorTint.RecommendedValues = { ColorToFString(FLinearColor(0.785339f, 0.879092f, 0.93125f).ToFColorSRGB()) };
     SceneColorTint.bRestrictToRecommended = false;
 
     FActorVariation VignetteIntensity;
     VignetteIntensity.Id = TEXT("vignette_intensity");
     VignetteIntensity.Type = EActorAttributeType::Float;
-    VignetteIntensity.RecommendedValues = {TEXT("0.4")};
+    VignetteIntensity.RecommendedValues = { TEXT("0.7") };
     VignetteIntensity.bRestrictToRecommended = false;
 
-    Definition.Variations.Append({ExposureMode,
-                                  LocalExposureMethod,
-                                  ExposureCompensation,
-                                  ShutterSpeed,
-                                  DirtMaskIntensity,
-                                  AmbientOcclusionIntensity,
-                                  AmbientOcclusionRadius,
-                                  DetailStrength,
-                                  ColorGain,
-                                  ISO,
-                                  Aperture,
-                                  PostProccess,
-                                  FilmGrainIntensity,
-                                  Gamma,
-                                  MBIntesity,
-                                  MBMaxDistortion,
-                                  LensFlareIntensity,
-                                  BloomMethod,
-                                  BloomIntensity,
-                                  MBMinObjectScreenSize,
-                                  ExposureMinBright,
-                                  ExposureMaxBright,
-                                  ExposureSpeedUp,
-                                  ExposureSpeedDown,
-                                  HighlightContrastScaleVariation,
-                                  ShadowContrastScaleVariation,
-                                  CalibrationConstant,
-                                  FocalDistance,
-                                  SensorWidth,
-                                  MaxAperture,
-                                  BladeCount,
-                                  DepthBlurAmount,
-                                  DepthBlurRadius,
-                                  FilmSlope,
-                                  FilmToe,
-                                  FilmShoulder,
-                                  FilmBlackClip,
-                                  FilmWhiteClip,
-                                  Temperature,
-                                  Tint,
-                                  ChromaticIntensity,
-                                  ChromaticOffset,
-                                  ColorSaturation,
-                                  ColorSaturationMidtones,
-                                  ColorSaturationHighlights,
-                                  ColorContrast,
-                                  ColorContrastMidtones,
-                                  ColorContrastHighlights,
-                                  ColorGamma,
-                                  HighlightsGamma,
-                                  ToneCurveAmount,
-                                  SceneColorTint,
-                                  VignetteIntensity});
+
+    Definition.Variations.Append({
+      ExposureMode,
+      ExposureCompensation,
+      ShutterSpeed,
+      ISO,
+      Aperture,
+      PostProccess,
+      Gamma,
+      MBIntesity,
+      MBMaxDistortion,
+      LensFlareIntensity,
+      BloomIntensity,
+      MBMinObjectScreenSize,
+      ExposureMinBright,
+      ExposureMaxBright,
+      ExposureSpeedUp,
+      ExposureSpeedDown,
+      HighlightContrastScaleVariation,
+      ShadowContrastScaleVariation,
+      CalibrationConstant,
+      FocalDistance,
+      SensorWidth,
+      MaxAperture,
+      BladeCount,
+      DepthBlurAmount,
+      DepthBlurRadius,
+      FilmSlope,
+      FilmToe,
+      FilmShoulder,
+      FilmBlackClip,
+      FilmWhiteClip,
+      Temperature,
+      Tint,
+      ChromaticIntensity,
+      ChromaticOffset,
+      ColorSaturation,
+      //ColorContrast,
+      //ColorGamma,
+      HighlightsGamma,
+      ToneCurveAmount,
+      SceneColorTint,
+      VignetteIntensity});
   }
 
   Success = CheckActorDefinition(Definition);
@@ -867,68 +770,69 @@ void UActorBlueprintFunctionLibrary::MakeNormalsCameraDefinition(bool &Success, 
   FActorVariation FOV;
   FOV.Id = TEXT("fov");
   FOV.Type = EActorAttributeType::Float;
-  FOV.RecommendedValues = {TEXT("90.0")};
+  FOV.RecommendedValues = { TEXT("90.0") };
   FOV.bRestrictToRecommended = false;
 
   // Resolution
   FActorVariation ResX;
   ResX.Id = TEXT("image_size_x");
   ResX.Type = EActorAttributeType::Int;
-  ResX.RecommendedValues = {TEXT("800")};
+  ResX.RecommendedValues = { TEXT("800") };
   ResX.bRestrictToRecommended = false;
 
   FActorVariation ResY;
   ResY.Id = TEXT("image_size_y");
   ResY.Type = EActorAttributeType::Int;
-  ResY.RecommendedValues = {TEXT("600")};
+  ResY.RecommendedValues = { TEXT("600") };
   ResY.bRestrictToRecommended = false;
 
   // Lens parameters
   FActorVariation LensCircleFalloff;
   LensCircleFalloff.Id = TEXT("lens_circle_falloff");
   LensCircleFalloff.Type = EActorAttributeType::Float;
-  LensCircleFalloff.RecommendedValues = {TEXT("5.0")};
+  LensCircleFalloff.RecommendedValues = { TEXT("5.0") };
   LensCircleFalloff.bRestrictToRecommended = false;
 
   FActorVariation LensCircleMultiplier;
   LensCircleMultiplier.Id = TEXT("lens_circle_multiplier");
   LensCircleMultiplier.Type = EActorAttributeType::Float;
-  LensCircleMultiplier.RecommendedValues = {TEXT("0.0")};
+  LensCircleMultiplier.RecommendedValues = { TEXT("0.0") };
   LensCircleMultiplier.bRestrictToRecommended = false;
 
   FActorVariation LensK;
   LensK.Id = TEXT("lens_k");
   LensK.Type = EActorAttributeType::Float;
-  LensK.RecommendedValues = {TEXT("-1.0")};
+  LensK.RecommendedValues = { TEXT("-1.0") };
   LensK.bRestrictToRecommended = false;
 
   FActorVariation LensKcube;
   LensKcube.Id = TEXT("lens_kcube");
   LensKcube.Type = EActorAttributeType::Float;
-  LensKcube.RecommendedValues = {TEXT("0.0")};
+  LensKcube.RecommendedValues = { TEXT("0.0") };
   LensKcube.bRestrictToRecommended = false;
 
   FActorVariation LensXSize;
   LensXSize.Id = TEXT("lens_x_size");
   LensXSize.Type = EActorAttributeType::Float;
-  LensXSize.RecommendedValues = {TEXT("0.08")};
+  LensXSize.RecommendedValues = { TEXT("0.08") };
   LensXSize.bRestrictToRecommended = false;
 
   FActorVariation LensYSize;
   LensYSize.Id = TEXT("lens_y_size");
   LensYSize.Type = EActorAttributeType::Float;
-  LensYSize.RecommendedValues = {TEXT("0.08")};
+  LensYSize.RecommendedValues = { TEXT("0.08") };
   LensYSize.bRestrictToRecommended = false;
 
-  Definition.Variations.Append({ResX,
-                                ResY,
-                                FOV,
-                                LensCircleFalloff,
-                                LensCircleMultiplier,
-                                LensK,
-                                LensKcube,
-                                LensXSize,
-                                LensYSize});
+  Definition.Variations.Append({
+      ResX,
+      ResY,
+      FOV,
+      LensCircleFalloff,
+      LensCircleMultiplier,
+      LensK,
+      LensKcube,
+      LensXSize,
+      LensYSize});
 
   Success = CheckActorDefinition(Definition);
 }
@@ -953,7 +857,7 @@ void UActorBlueprintFunctionLibrary::MakeIMUDefinition(
   FActorVariation NoiseSeed;
   NoiseSeed.Id = TEXT("noise_seed");
   NoiseSeed.Type = EActorAttributeType::Int;
-  NoiseSeed.RecommendedValues = {TEXT("0")};
+  NoiseSeed.RecommendedValues = { TEXT("0") };
   NoiseSeed.bRestrictToRecommended = false;
 
   // - Accelerometer Standard Deviation ----------
@@ -961,19 +865,19 @@ void UActorBlueprintFunctionLibrary::MakeIMUDefinition(
   FActorVariation StdDevAccelX;
   StdDevAccelX.Id = TEXT("noise_accel_stddev_x");
   StdDevAccelX.Type = EActorAttributeType::Float;
-  StdDevAccelX.RecommendedValues = {TEXT("0.0")};
+  StdDevAccelX.RecommendedValues = { TEXT("0.0") };
   StdDevAccelX.bRestrictToRecommended = false;
   // Y Component
   FActorVariation StdDevAccelY;
   StdDevAccelY.Id = TEXT("noise_accel_stddev_y");
   StdDevAccelY.Type = EActorAttributeType::Float;
-  StdDevAccelY.RecommendedValues = {TEXT("0.0")};
+  StdDevAccelY.RecommendedValues = { TEXT("0.0") };
   StdDevAccelY.bRestrictToRecommended = false;
   // Z Component
   FActorVariation StdDevAccelZ;
   StdDevAccelZ.Id = TEXT("noise_accel_stddev_z");
   StdDevAccelZ.Type = EActorAttributeType::Float;
-  StdDevAccelZ.RecommendedValues = {TEXT("0.0")};
+  StdDevAccelZ.RecommendedValues = { TEXT("0.0") };
   StdDevAccelZ.bRestrictToRecommended = false;
 
   // - Gyroscope Standard Deviation --------------
@@ -981,19 +885,19 @@ void UActorBlueprintFunctionLibrary::MakeIMUDefinition(
   FActorVariation StdDevGyroX;
   StdDevGyroX.Id = TEXT("noise_gyro_stddev_x");
   StdDevGyroX.Type = EActorAttributeType::Float;
-  StdDevGyroX.RecommendedValues = {TEXT("0.0")};
+  StdDevGyroX.RecommendedValues = { TEXT("0.0") };
   StdDevGyroX.bRestrictToRecommended = false;
   // Y Component
   FActorVariation StdDevGyroY;
   StdDevGyroY.Id = TEXT("noise_gyro_stddev_y");
   StdDevGyroY.Type = EActorAttributeType::Float;
-  StdDevGyroY.RecommendedValues = {TEXT("0.0")};
+  StdDevGyroY.RecommendedValues = { TEXT("0.0") };
   StdDevGyroY.bRestrictToRecommended = false;
   // Z Component
   FActorVariation StdDevGyroZ;
   StdDevGyroZ.Id = TEXT("noise_gyro_stddev_z");
   StdDevGyroZ.Type = EActorAttributeType::Float;
-  StdDevGyroZ.RecommendedValues = {TEXT("0.0")};
+  StdDevGyroZ.RecommendedValues = { TEXT("0.0") };
   StdDevGyroZ.bRestrictToRecommended = false;
 
   // - Gyroscope Bias ----------------------------
@@ -1001,31 +905,32 @@ void UActorBlueprintFunctionLibrary::MakeIMUDefinition(
   FActorVariation BiasGyroX;
   BiasGyroX.Id = TEXT("noise_gyro_bias_x");
   BiasGyroX.Type = EActorAttributeType::Float;
-  BiasGyroX.RecommendedValues = {TEXT("0.0")};
+  BiasGyroX.RecommendedValues = { TEXT("0.0") };
   BiasGyroX.bRestrictToRecommended = false;
   // Y Component
   FActorVariation BiasGyroY;
   BiasGyroY.Id = TEXT("noise_gyro_bias_y");
   BiasGyroY.Type = EActorAttributeType::Float;
-  BiasGyroY.RecommendedValues = {TEXT("0.0")};
+  BiasGyroY.RecommendedValues = { TEXT("0.0") };
   BiasGyroY.bRestrictToRecommended = false;
   // Z Component
   FActorVariation BiasGyroZ;
   BiasGyroZ.Id = TEXT("noise_gyro_bias_z");
   BiasGyroZ.Type = EActorAttributeType::Float;
-  BiasGyroZ.RecommendedValues = {TEXT("0.0")};
+  BiasGyroZ.RecommendedValues = { TEXT("0.0") };
   BiasGyroZ.bRestrictToRecommended = false;
 
-  Definition.Variations.Append({NoiseSeed,
-                                StdDevAccelX,
-                                StdDevAccelY,
-                                StdDevAccelZ,
-                                StdDevGyroX,
-                                StdDevGyroY,
-                                StdDevGyroZ,
-                                BiasGyroX,
-                                BiasGyroY,
-                                BiasGyroZ});
+  Definition.Variations.Append({
+    NoiseSeed,
+    StdDevAccelX,
+    StdDevAccelY,
+    StdDevAccelZ,
+    StdDevGyroX,
+    StdDevGyroY,
+    StdDevGyroZ,
+    BiasGyroX,
+    BiasGyroY,
+    BiasGyroZ});
 
   Success = CheckActorDefinition(Definition);
 }
@@ -1049,39 +954,40 @@ void UActorBlueprintFunctionLibrary::MakeRadarDefinition(
   FActorVariation HorizontalFOV;
   HorizontalFOV.Id = TEXT("horizontal_fov");
   HorizontalFOV.Type = EActorAttributeType::Float;
-  HorizontalFOV.RecommendedValues = {TEXT("30")};
+  HorizontalFOV.RecommendedValues = { TEXT("30") };
   HorizontalFOV.bRestrictToRecommended = false;
 
   FActorVariation VerticalFOV;
   VerticalFOV.Id = TEXT("vertical_fov");
   VerticalFOV.Type = EActorAttributeType::Float;
-  VerticalFOV.RecommendedValues = {TEXT("30")};
+  VerticalFOV.RecommendedValues = { TEXT("30") };
   VerticalFOV.bRestrictToRecommended = false;
 
   FActorVariation Range;
   Range.Id = TEXT("range");
   Range.Type = EActorAttributeType::Float;
-  Range.RecommendedValues = {TEXT("100")};
+  Range.RecommendedValues = { TEXT("100") };
   Range.bRestrictToRecommended = false;
 
   FActorVariation PointsPerSecond;
   PointsPerSecond.Id = TEXT("points_per_second");
   PointsPerSecond.Type = EActorAttributeType::Int;
-  PointsPerSecond.RecommendedValues = {TEXT("1500")};
+  PointsPerSecond.RecommendedValues = { TEXT("1500") };
   PointsPerSecond.bRestrictToRecommended = false;
 
   // Noise seed
   FActorVariation NoiseSeed;
   NoiseSeed.Id = TEXT("noise_seed");
   NoiseSeed.Type = EActorAttributeType::Int;
-  NoiseSeed.RecommendedValues = {TEXT("0")};
+  NoiseSeed.RecommendedValues = { TEXT("0") };
   NoiseSeed.bRestrictToRecommended = false;
 
-  Definition.Variations.Append({HorizontalFOV,
-                                VerticalFOV,
-                                Range,
-                                PointsPerSecond,
-                                NoiseSeed});
+  Definition.Variations.Append({
+    HorizontalFOV,
+    VerticalFOV,
+    Range,
+    PointsPerSecond,
+    NoiseSeed});
 
   Success = CheckActorDefinition(Definition);
 }
@@ -1108,97 +1014,96 @@ void UActorBlueprintFunctionLibrary::MakeLidarDefinition(
   FActorVariation Channels;
   Channels.Id = TEXT("channels");
   Channels.Type = EActorAttributeType::Int;
-  Channels.RecommendedValues = {TEXT("64")};
+  Channels.RecommendedValues = { TEXT("64") };
   // Range.
   FActorVariation Range;
   Range.Id = TEXT("range");
   Range.Type = EActorAttributeType::Float;
-  Range.RecommendedValues = {TEXT("50.0")}; // 50 meters
+  Range.RecommendedValues = { TEXT("50.0") }; // 50 meters
   // Points per second.
   FActorVariation PointsPerSecond;
   PointsPerSecond.Id = TEXT("points_per_second");
   PointsPerSecond.Type = EActorAttributeType::Int;
-  PointsPerSecond.RecommendedValues = {TEXT("600000")};
+  PointsPerSecond.RecommendedValues = { TEXT("600000") };
   // Frequency.
   FActorVariation Frequency;
   Frequency.Id = TEXT("rotation_frequency");
   Frequency.Type = EActorAttributeType::Float;
-  Frequency.RecommendedValues = {TEXT("60.0")};
+  Frequency.RecommendedValues = { TEXT("60.0") };
   // Upper FOV limit.
   FActorVariation UpperFOV;
   UpperFOV.Id = TEXT("upper_fov");
   UpperFOV.Type = EActorAttributeType::Float;
-  UpperFOV.RecommendedValues = {TEXT("10.0")};
+  UpperFOV.RecommendedValues = { TEXT("10.0") };
   // Lower FOV limit.
   FActorVariation LowerFOV;
   LowerFOV.Id = TEXT("lower_fov");
   LowerFOV.Type = EActorAttributeType::Float;
-  LowerFOV.RecommendedValues = {TEXT("-30.0")};
+  LowerFOV.RecommendedValues = { TEXT("-30.0") };
   // Horizontal FOV.
   FActorVariation HorizontalFOV;
   HorizontalFOV.Id = TEXT("horizontal_fov");
   HorizontalFOV.Type = EActorAttributeType::Float;
-  HorizontalFOV.RecommendedValues = {TEXT("360.0")};
+  HorizontalFOV.RecommendedValues = { TEXT("360.0") };
   // Atmospheric Attenuation Rate.
   FActorVariation AtmospAttenRate;
   AtmospAttenRate.Id = TEXT("atmosphere_attenuation_rate");
   AtmospAttenRate.Type = EActorAttributeType::Float;
-  AtmospAttenRate.RecommendedValues = {TEXT("0.004")};
+  AtmospAttenRate.RecommendedValues = { TEXT("0.004") };
   // Noise seed
   FActorVariation NoiseSeed;
   NoiseSeed.Id = TEXT("noise_seed");
   NoiseSeed.Type = EActorAttributeType::Int;
-  NoiseSeed.RecommendedValues = {TEXT("0")};
+  NoiseSeed.RecommendedValues = { TEXT("0") };
   NoiseSeed.bRestrictToRecommended = false;
   // Dropoff General Rate
   FActorVariation DropOffGenRate;
   DropOffGenRate.Id = TEXT("dropoff_general_rate");
   DropOffGenRate.Type = EActorAttributeType::Float;
-  DropOffGenRate.RecommendedValues = {TEXT("0.45")};
+  DropOffGenRate.RecommendedValues = { TEXT("0.45") };
   // Dropoff intensity limit.
   FActorVariation DropOffIntensityLimit;
   DropOffIntensityLimit.Id = TEXT("dropoff_intensity_limit");
   DropOffIntensityLimit.Type = EActorAttributeType::Float;
-  DropOffIntensityLimit.RecommendedValues = {TEXT("0.8")};
+  DropOffIntensityLimit.RecommendedValues = { TEXT("0.8") };
   // Dropoff at zero intensity.
   FActorVariation DropOffAtZeroIntensity;
   DropOffAtZeroIntensity.Id = TEXT("dropoff_zero_intensity");
   DropOffAtZeroIntensity.Type = EActorAttributeType::Float;
-  DropOffAtZeroIntensity.RecommendedValues = {TEXT("0.4")};
+  DropOffAtZeroIntensity.RecommendedValues = { TEXT("0.4") };
   // Noise in lidar cloud points.
   FActorVariation StdDevLidar;
   StdDevLidar.Id = TEXT("noise_stddev");
   StdDevLidar.Type = EActorAttributeType::Float;
-  StdDevLidar.RecommendedValues = {TEXT("0.0")};
+  StdDevLidar.RecommendedValues = { TEXT("0.0") };
 
-  if (Id == "ray_cast")
-  {
-    Definition.Variations.Append({Channels,
-                                  Range,
-                                  PointsPerSecond,
-                                  Frequency,
-                                  UpperFOV,
-                                  LowerFOV,
-                                  AtmospAttenRate,
-                                  NoiseSeed,
-                                  DropOffGenRate,
-                                  DropOffIntensityLimit,
-                                  DropOffAtZeroIntensity,
-                                  StdDevLidar,
-                                  HorizontalFOV});
+  if (Id == "ray_cast") {
+    Definition.Variations.Append({
+      Channels,
+      Range,
+      PointsPerSecond,
+      Frequency,
+      UpperFOV,
+      LowerFOV,
+      AtmospAttenRate,
+      NoiseSeed,
+      DropOffGenRate,
+      DropOffIntensityLimit,
+      DropOffAtZeroIntensity,
+      StdDevLidar,
+      HorizontalFOV});
   }
-  else if (Id == "ray_cast_semantic")
-  {
-    Definition.Variations.Append({Channels,
-                                  Range,
-                                  PointsPerSecond,
-                                  Frequency,
-                                  UpperFOV,
-                                  LowerFOV,
-                                  HorizontalFOV});
+  else if (Id == "ray_cast_semantic") {
+    Definition.Variations.Append({
+      Channels,
+      Range,
+      PointsPerSecond,
+      Frequency,
+      UpperFOV,
+      LowerFOV,
+      HorizontalFOV});
   }
-  else
-  {
+  else {
     DEBUG_ASSERT(false);
   }
 
@@ -1225,52 +1130,53 @@ void UActorBlueprintFunctionLibrary::MakeGnssDefinition(
   FActorVariation NoiseSeed;
   NoiseSeed.Id = TEXT("noise_seed");
   NoiseSeed.Type = EActorAttributeType::Int;
-  NoiseSeed.RecommendedValues = {TEXT("0")};
+  NoiseSeed.RecommendedValues = { TEXT("0") };
   NoiseSeed.bRestrictToRecommended = false;
 
   // - Latitude ----------------------------------
   FActorVariation StdDevLat;
   StdDevLat.Id = TEXT("noise_lat_stddev");
   StdDevLat.Type = EActorAttributeType::Float;
-  StdDevLat.RecommendedValues = {TEXT("0.0")};
+  StdDevLat.RecommendedValues = { TEXT("0.0") };
   StdDevLat.bRestrictToRecommended = false;
   FActorVariation BiasLat;
   BiasLat.Id = TEXT("noise_lat_bias");
   BiasLat.Type = EActorAttributeType::Float;
-  BiasLat.RecommendedValues = {TEXT("0.0")};
+  BiasLat.RecommendedValues = { TEXT("0.0") };
   BiasLat.bRestrictToRecommended = false;
 
   // - Longitude ---------------------------------
   FActorVariation StdDevLong;
   StdDevLong.Id = TEXT("noise_lon_stddev");
   StdDevLong.Type = EActorAttributeType::Float;
-  StdDevLong.RecommendedValues = {TEXT("0.0")};
+  StdDevLong.RecommendedValues = { TEXT("0.0") };
   StdDevLong.bRestrictToRecommended = false;
   FActorVariation BiasLong;
   BiasLong.Id = TEXT("noise_lon_bias");
   BiasLong.Type = EActorAttributeType::Float;
-  BiasLong.RecommendedValues = {TEXT("0.0")};
+  BiasLong.RecommendedValues = { TEXT("0.0") };
   BiasLong.bRestrictToRecommended = false;
 
   // - Altitude ----------------------------------
   FActorVariation StdDevAlt;
   StdDevAlt.Id = TEXT("noise_alt_stddev");
   StdDevAlt.Type = EActorAttributeType::Float;
-  StdDevAlt.RecommendedValues = {TEXT("0.0")};
+  StdDevAlt.RecommendedValues = { TEXT("0.0") };
   StdDevAlt.bRestrictToRecommended = false;
   FActorVariation BiasAlt;
   BiasAlt.Id = TEXT("noise_alt_bias");
   BiasAlt.Type = EActorAttributeType::Float;
-  BiasAlt.RecommendedValues = {TEXT("0.0")};
+  BiasAlt.RecommendedValues = { TEXT("0.0") };
   BiasAlt.bRestrictToRecommended = false;
 
-  Definition.Variations.Append({NoiseSeed,
-                                StdDevLat,
-                                BiasLat,
-                                StdDevLong,
-                                BiasLong,
-                                StdDevAlt,
-                                BiasAlt});
+  Definition.Variations.Append({
+    NoiseSeed,
+    StdDevLat,
+    BiasLat,
+    StdDevLong,
+    BiasLong,
+    StdDevAlt,
+    BiasAlt});
 
   Success = CheckActorDefinition(Definition);
 }
@@ -1283,7 +1189,7 @@ void UActorBlueprintFunctionLibrary::MakeVehicleDefinition(
   /// @todo We need to validate here the params.
   FillIdAndTags(Definition, TEXT("vehicle"), Parameters.Make, Parameters.Model);
   AddRecommendedValuesForActorRoleName(Definition,
-                                       {TEXT("autopilot"), TEXT("scenario"), TEXT("ego_vehicle")});
+      {TEXT("autopilot"), TEXT("scenario"), TEXT("ego_vehicle")});
   Definition.Class = Parameters.Class;
 
   if (Parameters.RecommendedColors.Num() > 0)
@@ -1327,44 +1233,44 @@ void UActorBlueprintFunctionLibrary::MakeVehicleDefinition(
   Definition.Variations.Emplace(TerramechanicsAttribute);
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("object_type"),
-      EActorAttributeType::String,
-      Parameters.ObjectType});
+    TEXT("object_type"),
+    EActorAttributeType::String,
+    Parameters.ObjectType});
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("base_type"),
-      EActorAttributeType::String,
-      Parameters.BaseType});
+    TEXT("base_type"),
+    EActorAttributeType::String,
+    Parameters.BaseType});
   Success = CheckActorDefinition(Definition);
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("special_type"),
-      EActorAttributeType::String,
-      Parameters.SpecialType});
+    TEXT("special_type"),
+    EActorAttributeType::String,
+    Parameters.SpecialType});
   Success = CheckActorDefinition(Definition);
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("number_of_wheels"),
-      EActorAttributeType::Int,
-      FString::FromInt(Parameters.NumberOfWheels)});
+    TEXT("number_of_wheels"),
+    EActorAttributeType::Int,
+    FString::FromInt(Parameters.NumberOfWheels)});
   Success = CheckActorDefinition(Definition);
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("generation"),
-      EActorAttributeType::Int,
-      FString::FromInt(Parameters.Generation)});
+    TEXT("generation"),
+    EActorAttributeType::Int,
+    FString::FromInt(Parameters.Generation)});
   Success = CheckActorDefinition(Definition);
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("has_dynamic_doors"),
-      EActorAttributeType::Bool,
-      Parameters.HasDynamicDoors ? TEXT("true") : TEXT("false")});
+    TEXT("has_dynamic_doors"),
+    EActorAttributeType::Bool,
+    Parameters.HasDynamicDoors ? TEXT("true") : TEXT("false")});
   Success = CheckActorDefinition(Definition);
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("has_lights"),
-      EActorAttributeType::Bool,
-      Parameters.HasLights ? TEXT("true") : TEXT("false")});
+    TEXT("has_lights"),
+    EActorAttributeType::Bool,
+    Parameters.HasLights ? TEXT("true") : TEXT("false")});
   Success = CheckActorDefinition(Definition);
 }
 
@@ -1399,52 +1305,43 @@ void UActorBlueprintFunctionLibrary::MakePedestrianDefinition(
     FActorDefinition &Definition)
 {
   /// @todo We need to validate here the params.
-  FillIdAndTags(Definition, TEXT("walker"), TEXT("pedestrian"), Parameters.Id);
+  FillIdAndTags(Definition, TEXT("walker"),  TEXT("pedestrian"), Parameters.Id);
   AddRecommendedValuesForActorRoleName(Definition, {TEXT("pedestrian")});
   Definition.Class = Parameters.Class;
 
-  auto GetGender = [](EPedestrianGender Value)
-  {
+  auto GetGender = [](EPedestrianGender Value) {
     switch (Value)
     {
-    case EPedestrianGender::Female:
-      return TEXT("female");
-    case EPedestrianGender::Male:
-      return TEXT("male");
-    default:
-      return TEXT("other");
+      case EPedestrianGender::Female: return TEXT("female");
+      case EPedestrianGender::Male:   return TEXT("male");
+      default:                        return TEXT("other");
     }
   };
 
-  auto GetAge = [](EPedestrianAge Value)
-  {
+  auto GetAge = [](EPedestrianAge Value) {
     switch (Value)
     {
-    case EPedestrianAge::Child:
-      return TEXT("child");
-    case EPedestrianAge::Teenager:
-      return TEXT("teenager");
-    case EPedestrianAge::Elderly:
-      return TEXT("elderly");
-    default:
-      return TEXT("adult");
+      case EPedestrianAge::Child:     return TEXT("child");
+      case EPedestrianAge::Teenager:  return TEXT("teenager");
+      case EPedestrianAge::Elderly:   return TEXT("elderly");
+      default:                        return TEXT("adult");
     }
   };
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("gender"),
-      EActorAttributeType::String,
-      GetGender(Parameters.Gender)});
+    TEXT("gender"),
+    EActorAttributeType::String,
+    GetGender(Parameters.Gender)});
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("generation"),
-      EActorAttributeType::Int,
-      FString::FromInt(Parameters.Generation)});
+    TEXT("generation"),
+    EActorAttributeType::Int,
+    FString::FromInt(Parameters.Generation)});
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("age"),
-      EActorAttributeType::String,
-      GetAge(Parameters.Age)});
+    TEXT("age"),
+    EActorAttributeType::String,
+    GetAge(Parameters.Age)});
 
   if (Parameters.Speed.Num() > 0)
   {
@@ -1462,7 +1359,7 @@ void UActorBlueprintFunctionLibrary::MakePedestrianDefinition(
   FActorVariation IsInvincible;
   IsInvincible.Id = TEXT("is_invincible");
   IsInvincible.Type = EActorAttributeType::Bool;
-  IsInvincible.RecommendedValues = {TEXT("true")};
+  IsInvincible.RecommendedValues = { TEXT("true") };
   IsInvincible.bRestrictToRecommended = false;
   Definition.Variations.Emplace(IsInvincible);
 
@@ -1500,32 +1397,25 @@ void UActorBlueprintFunctionLibrary::MakePropDefinition(
     FActorDefinition &Definition)
 {
   /// @todo We need to validate here the params.
-  FillIdAndTags(Definition, TEXT("static"), TEXT("prop"), Parameters.Name);
+  FillIdAndTags(Definition, TEXT("static"),  TEXT("prop"), Parameters.Name);
   AddRecommendedValuesForActorRoleName(Definition, {TEXT("prop")});
 
-  auto GetSize = [](EPropSize Value)
-  {
+  auto GetSize = [](EPropSize Value) {
     switch (Value)
     {
-    case EPropSize::Tiny:
-      return TEXT("tiny");
-    case EPropSize::Small:
-      return TEXT("small");
-    case EPropSize::Medium:
-      return TEXT("medium");
-    case EPropSize::Big:
-      return TEXT("big");
-    case EPropSize::Huge:
-      return TEXT("huge");
-    default:
-      return TEXT("unknown");
+      case EPropSize::Tiny:    return TEXT("tiny");
+      case EPropSize::Small:   return TEXT("small");
+      case EPropSize::Medium:  return TEXT("medium");
+      case EPropSize::Big:     return TEXT("big");
+      case EPropSize::Huge:    return TEXT("huge");
+      default:                 return TEXT("unknown");
     }
   };
 
   Definition.Attributes.Emplace(FActorAttribute{
-      TEXT("size"),
-      EActorAttributeType::String,
-      GetSize(Parameters.Size)});
+    TEXT("size"),
+    EActorAttributeType::String,
+    GetSize(Parameters.Size)});
 
   Success = CheckActorDefinition(Definition);
 }
@@ -1538,9 +1428,9 @@ void UActorBlueprintFunctionLibrary::MakePropDefinitions(
 }
 
 void UActorBlueprintFunctionLibrary::MakeBlueprintDefinition(
-    const FBlueprintParameters &Parameters,
-    bool &Success,
-    FActorDefinition &Definition)
+  const FBlueprintParameters &Parameters,
+  bool &Success,
+  FActorDefinition &Definition)
 {
   FillIdAndTags(Definition, TEXT("blueprint"), Parameters.Name);
   AddRecommendedValuesForActorRoleName(Definition, {TEXT("blueprint")});
@@ -1549,15 +1439,18 @@ void UActorBlueprintFunctionLibrary::MakeBlueprintDefinition(
   //   EActorAttributeType::String,
   //   Parameters.ObjectType});
 
+
   Success = CheckActorDefinition(Definition);
+
 }
 
 void UActorBlueprintFunctionLibrary::MakeBlueprintDefinitions(
-    const TArray<FBlueprintParameters> &ParameterArray,
-    TArray<FActorDefinition> &Definitions)
+  const TArray<FBlueprintParameters> &ParameterArray,
+  TArray<FActorDefinition> &Definitions)
 {
   FillActorDefinitionArray(ParameterArray, Definitions, &MakeBlueprintDefinition);
 }
+
 
 void UActorBlueprintFunctionLibrary::MakeObstacleDetectorDefinitions(
     const FString &Type,
@@ -1570,31 +1463,34 @@ void UActorBlueprintFunctionLibrary::MakeObstacleDetectorDefinitions(
   FActorVariation distance;
   distance.Id = TEXT("distance");
   distance.Type = EActorAttributeType::Float;
-  distance.RecommendedValues = {TEXT("5.0")};
+  distance.RecommendedValues = { TEXT("5.0") };
   distance.bRestrictToRecommended = false;
   // HitRadius.
   FActorVariation hitradius;
   hitradius.Id = TEXT("hit_radius");
   hitradius.Type = EActorAttributeType::Float;
-  hitradius.RecommendedValues = {TEXT("0.5")};
+  hitradius.RecommendedValues = { TEXT("0.5") };
   hitradius.bRestrictToRecommended = false;
   // Only Dynamics
   FActorVariation onlydynamics;
   onlydynamics.Id = TEXT("only_dynamics");
   onlydynamics.Type = EActorAttributeType::Bool;
-  onlydynamics.RecommendedValues = {TEXT("false")};
+  onlydynamics.RecommendedValues = { TEXT("false") };
   onlydynamics.bRestrictToRecommended = false;
   // Debug Line Trace
   FActorVariation debuglinetrace;
   debuglinetrace.Id = TEXT("debug_linetrace");
   debuglinetrace.Type = EActorAttributeType::Bool;
-  debuglinetrace.RecommendedValues = {TEXT("false")};
+  debuglinetrace.RecommendedValues = { TEXT("false") };
   debuglinetrace.bRestrictToRecommended = false;
 
-  Definition.Variations.Append({distance,
-                                hitradius,
-                                onlydynamics,
-                                debuglinetrace});
+  Definition.Variations.Append({
+    distance,
+    hitradius,
+    onlydynamics,
+    debuglinetrace
+  });
+
 }
 /// ============================================================================
 /// -- Helpers to retrieve attribute values ------------------------------------
@@ -1662,10 +1558,10 @@ FColor UActorBlueprintFunctionLibrary::ActorAttributeToColor(
   if (Channels.Num() != 3)
   {
     UE_LOG(LogCarla,
-           Error,
-           TEXT("ActorAttribute '%s': invalid color '%s'"),
-           *ActorAttribute.Id,
-           *ActorAttribute.Value);
+        Error,
+        TEXT("ActorAttribute '%s': invalid color '%s'"),
+        *ActorAttribute.Id,
+        *ActorAttribute.Value);
     return Default;
   }
   TArray<uint8> Colors;
@@ -1675,10 +1571,10 @@ FColor UActorBlueprintFunctionLibrary::ActorAttributeToColor(
     if ((Val < 0) || (Val > std::numeric_limits<uint8>::max()))
     {
       UE_LOG(LogCarla,
-             Error,
-             TEXT("ActorAttribute '%s': invalid color '%s'"),
-             *ActorAttribute.Id,
-             *ActorAttribute.Value);
+          Error,
+          TEXT("ActorAttribute '%s': invalid color '%s'"),
+          *ActorAttribute.Id,
+          *ActorAttribute.Value);
       return Default;
     }
     Colors.Add(Val);
@@ -1705,10 +1601,10 @@ FVector UActorBlueprintFunctionLibrary::ActorAttributeToVector(
   if (Values.Num() != 3)
   {
     UE_LOG(LogCarla,
-           Error,
-           TEXT("ActorAttribute '%s': invalid vector '%s' must contain 3 values separated with comma"),
-           *ActorAttribute.Id,
-           *ActorAttribute.Value);
+        Error,
+        TEXT("ActorAttribute '%s': invalid vector '%s' must contain 3 values separated with comma"),
+        *ActorAttribute.Id,
+        *ActorAttribute.Value);
     return Default;
   }
 
@@ -1724,7 +1620,9 @@ bool UActorBlueprintFunctionLibrary::RetrieveActorAttributeToBool(
     const TMap<FString, FActorAttribute> &Attributes,
     bool Default)
 {
-  return Attributes.Contains(Id) ? ActorAttributeToBool(Attributes[Id], Default) : Default;
+  return Attributes.Contains(Id) ?
+         ActorAttributeToBool(Attributes[Id], Default) :
+         Default;
 }
 
 int32 UActorBlueprintFunctionLibrary::RetrieveActorAttributeToInt(
@@ -1732,7 +1630,9 @@ int32 UActorBlueprintFunctionLibrary::RetrieveActorAttributeToInt(
     const TMap<FString, FActorAttribute> &Attributes,
     int32 Default)
 {
-  return Attributes.Contains(Id) ? ActorAttributeToInt(Attributes[Id], Default) : Default;
+  return Attributes.Contains(Id) ?
+         ActorAttributeToInt(Attributes[Id], Default) :
+         Default;
 }
 
 float UActorBlueprintFunctionLibrary::RetrieveActorAttributeToFloat(
@@ -1740,7 +1640,9 @@ float UActorBlueprintFunctionLibrary::RetrieveActorAttributeToFloat(
     const TMap<FString, FActorAttribute> &Attributes,
     float Default)
 {
-  return Attributes.Contains(Id) ? ActorAttributeToFloat(Attributes[Id], Default) : Default;
+  return Attributes.Contains(Id) ?
+         ActorAttributeToFloat(Attributes[Id], Default) :
+         Default;
 }
 
 FString UActorBlueprintFunctionLibrary::RetrieveActorAttributeToString(
@@ -1748,7 +1650,9 @@ FString UActorBlueprintFunctionLibrary::RetrieveActorAttributeToString(
     const TMap<FString, FActorAttribute> &Attributes,
     const FString &Default)
 {
-  return Attributes.Contains(Id) ? ActorAttributeToString(Attributes[Id], Default) : Default;
+  return Attributes.Contains(Id) ?
+         ActorAttributeToString(Attributes[Id], Default) :
+         Default;
 }
 
 FColor UActorBlueprintFunctionLibrary::RetrieveActorAttributeToColor(
@@ -1756,7 +1660,9 @@ FColor UActorBlueprintFunctionLibrary::RetrieveActorAttributeToColor(
     const TMap<FString, FActorAttribute> &Attributes,
     const FColor &Default)
 {
-  return Attributes.Contains(Id) ? ActorAttributeToColor(Attributes[Id], Default) : Default;
+  return Attributes.Contains(Id) ?
+         ActorAttributeToColor(Attributes[Id], Default) :
+         Default;
 }
 
 FVector UActorBlueprintFunctionLibrary::RetrieveActorAttributeToVector(
@@ -1764,7 +1670,9 @@ FVector UActorBlueprintFunctionLibrary::RetrieveActorAttributeToVector(
     const TMap<FString, FActorAttribute> &Attributes,
     const FVector &Default)
 {
-  return Attributes.Contains(Id) ? ActorAttributeToVector(Attributes[Id], Default) : Default;
+  return Attributes.Contains(Id) ?
+         ActorAttributeToVector(Attributes[Id], Default) :
+         Default;
 }
 
 /// ============================================================================
@@ -1774,14 +1682,14 @@ FVector UActorBlueprintFunctionLibrary::RetrieveActorAttributeToVector(
 // Here we do different checks when we are in editor because we don't want the
 // editor crashing while people are testing new actor definitions.
 #if WITH_EDITOR
-#define CARLA_ABFL_CHECK_ACTOR(ActorPtr)                      \
-  if (!IsValid(ActorPtr))                                     \
+#  define CARLA_ABFL_CHECK_ACTOR(ActorPtr)                    \
+  if (!IsValid(ActorPtr))     \
   {                                                           \
     UE_LOG(LogCarla, Error, TEXT("Cannot set empty actor!")); \
     return;                                                   \
   }
 #else
-#define CARLA_ABFL_CHECK_ACTOR(ActorPtr) \
+#  define CARLA_ABFL_CHECK_ACTOR(ActorPtr) \
   IsValid(ActorPtr);
 #endif // WITH_EDITOR
 
@@ -1799,8 +1707,8 @@ void UActorBlueprintFunctionLibrary::SetCamera(
   {
     Camera->EnablePostProcessingEffects(
         ActorAttributeToBool(
-            Description.Variations["enable_postprocess_effects"],
-            true));
+        Description.Variations["enable_postprocess_effects"],
+        true));
     Camera->SetTargetGamma(
         RetrieveActorAttributeToFloat("gamma", Description.Variations, 1.0f));
     Camera->SetMotionBlurIntensity(
@@ -1810,23 +1718,11 @@ void UActorBlueprintFunctionLibrary::SetCamera(
     Camera->SetMotionBlurMinObjectScreenSize(
         RetrieveActorAttributeToFloat("motion_blur_min_object_screen_size", Description.Variations, 0.0f));
     Camera->SetLensFlareIntensity(
-        RetrieveActorAttributeToFloat("lens_flare_intensity", Description.Variations, 0.01f));
+        RetrieveActorAttributeToFloat("lens_flare_intensity", Description.Variations, 0.2f));
     Camera->SetBloomIntensity(
-        RetrieveActorAttributeToFloat("bloom_intensity", Description.Variations, 0.5f));
-    Camera->SetDirtMaskIntensity(
-        RetrieveActorAttributeToFloat("dirt_mask_intensity", Description.Variations, 50.0f));
-
-    if (RetrieveActorAttributeToString("bloom_method", Description.Variations, "standard") != "convolution")
-    {
-      Camera->SetBloomMethod(EBloomMethod::BM_FFT);
-    }
-    else
-    {
-      Camera->SetBloomMethod(EBloomMethod::BM_FFT);
-    }
-
+        RetrieveActorAttributeToFloat("bloom_intensity", Description.Variations, 0.0f));
     // Exposure, histogram mode by default
-    if (RetrieveActorAttributeToString("exposure_mode", Description.Variations, "histogram") != "manual")
+    if (RetrieveActorAttributeToString("exposure_mode", Description.Variations, "histogram") != "histogram")
     {
       Camera->SetExposureMethod(EAutoExposureMethod::AEM_Manual);
     }
@@ -1834,24 +1730,14 @@ void UActorBlueprintFunctionLibrary::SetCamera(
     {
       Camera->SetExposureMethod(EAutoExposureMethod::AEM_Histogram);
     }
-
-    if (RetrieveActorAttributeToString("local_exposure_method", Description.Variations, "bilateral") != "bilateral")
-    {
-      Camera->SetLocalExposureMethod(ELocalExposureMethod::Bilateral);
-    }
-    else
-    {
-      Camera->SetLocalExposureMethod(ELocalExposureMethod::Bilateral);
-    }
-
     Camera->SetExposureCompensation(
-        RetrieveActorAttributeToFloat("exposure_compensation", Description.Variations, 0.5f));
+        RetrieveActorAttributeToFloat("exposure_compensation", Description.Variations, 1.5f));
     Camera->SetShutterSpeed(
-        RetrieveActorAttributeToFloat("shutter_speed", Description.Variations, 60.0f));
+        RetrieveActorAttributeToFloat("shutter_speed", Description.Variations, 15.0f));
     Camera->SetISO(
-        RetrieveActorAttributeToFloat("iso", Description.Variations, 100.0f));
+        RetrieveActorAttributeToFloat("iso", Description.Variations, 300000.0f));
     Camera->SetAperture(
-        RetrieveActorAttributeToFloat("fstop", Description.Variations, 8.0f));
+        RetrieveActorAttributeToFloat("fstop", Description.Variations, 9.8f));
 
     Camera->SetExposureMinBrightness(
         RetrieveActorAttributeToFloat("exposure_min_bright", Description.Variations, 0.0f));
@@ -1864,7 +1750,7 @@ void UActorBlueprintFunctionLibrary::SetCamera(
     Camera->SetHighlightContrastScale(
         RetrieveActorAttributeToFloat("highlight_contrast_scale", Description.Variations, 0.7f));
     Camera->SetShadowContrastScale(
-        RetrieveActorAttributeToFloat("shadow_constrast_scale", Description.Variations, 0.6f));
+        RetrieveActorAttributeToFloat("shadow_constrast_scale", Description.Variations, 0.65f));
     // This is deprecated:
     Camera->SetExposureCalibrationConstant(
         RetrieveActorAttributeToFloat("calibration_constant", Description.Variations, 16.0f));
@@ -1883,9 +1769,9 @@ void UActorBlueprintFunctionLibrary::SetCamera(
         RetrieveActorAttributeToInt("blade_count", Description.Variations, 5));
 
     Camera->SetFilmSlope(
-        RetrieveActorAttributeToFloat("slope", Description.Variations, 0.7f));
+        RetrieveActorAttributeToFloat("slope", Description.Variations, 0.88f));
     Camera->SetFilmToe(
-        RetrieveActorAttributeToFloat("toe", Description.Variations, 0.25f));
+        RetrieveActorAttributeToFloat("toe", Description.Variations, 0.55f));
     Camera->SetFilmShoulder(
         RetrieveActorAttributeToFloat("shoulder", Description.Variations, 0.26f));
     Camera->SetFilmBlackClip(
@@ -1903,53 +1789,19 @@ void UActorBlueprintFunctionLibrary::SetCamera(
     Camera->SetChromAberrOffset(
         RetrieveActorAttributeToFloat("chromatic_aberration_offset", Description.Variations, 0.0f));
 
-    auto ColorSaturation = FLinearColor(RetrieveActorAttributeToColor("color_saturation", Description.Variations, FLinearColor(0.696528f, 0.802778f, 0.850000f, 1.000000f).ToFColorSRGB()));
+    auto ColorSaturation = FLinearColor(RetrieveActorAttributeToColor("color_saturation", Description.Variations, FLinearColor(0.5f, 0.5f, 0.5f).ToFColorSRGB()));
     Camera->SetColorSaturation(
         FVector4(ColorSaturation.R, ColorSaturation.G, ColorSaturation.B, ColorSaturation.A));
 
-    auto ColorSaturationMid = FLinearColor(RetrieveActorAttributeToColor("color_saturation_midtones", Description.Variations, FLinearColor(0.8f, 1.4f, 0.9f, 1.0f).ToFColorSRGB()));
-    Camera->SetColorSaturationMidtones(
-        FVector4(ColorSaturationMid.R, ColorSaturationMid.G, ColorSaturationMid.B, 1.0f));
-
-    auto ColorSaturationHigh = FLinearColor(RetrieveActorAttributeToColor("color_saturation_highlights", Description.Variations, FLinearColor(1.0f, 1.0f, 1.0f, 1.0f).ToFColorSRGB()));
-    Camera->SetColorSaturationHighlights(
-        FVector4(ColorSaturationHigh.R, ColorSaturationHigh.G, ColorSaturationHigh.B, 1.0f));
-
     // Temporal comments until FVector is implemented in clientside
-    auto ColorContrast = FLinearColor(RetrieveActorAttributeToColor("color_contrast", Description.Variations, FLinearColor(0.9f, 0.9f, 0.9f).ToFColorSRGB()));
+    FVector ColorContrast = FVector(RetrieveActorAttributeToVector("color_contrast", Description.Variations, FVector(1.6f, 1.6f, 1.6f)));
     Camera->SetColorContrast(
-        FVector4(ColorContrast.R, ColorContrast.G, ColorContrast.B, 1.0f));
-
-    auto ColorContrastMid = FLinearColor(RetrieveActorAttributeToColor("color_contrast_midtones", Description.Variations, FLinearColor(1.2f, 1.2f, 1.2f).ToFColorSRGB()));
-    Camera->SetColorContrastMidtones(
-        FVector4(ColorContrastMid.R, ColorContrastMid.G, ColorContrastMid.B, 1.0f));
-
-    auto ColorContrastHigh = FLinearColor(RetrieveActorAttributeToColor("color_contrast_highlights", Description.Variations, FLinearColor(1.5f, 1.5f, 1.5f).ToFColorSRGB()));
-    Camera->SetColorContrastHighlights(
-        FVector4(ColorContrastHigh.R, ColorContrastHigh.G, ColorContrastHigh.B, 1.0f));
-
-    Camera->SetGlobalGain(
-        FVector4(0.9f, 0.9f, 0.9f, 1.0f));
-
-    Camera->SetBlueCorrection(
-        RetrieveActorAttributeToFloat("blue_correction", Description.Variations, 0.6f));
-
-    Camera->SetDetailStrength(
-        RetrieveActorAttributeToFloat("detail_strength", Description.Variations, 1.2f));
-
-    Camera->SetFilmGrainIntensity(
-        RetrieveActorAttributeToFloat("film_grain_intensity", Description.Variations, 0.1f));
-
-    Camera->SetAOIntensity(
-        RetrieveActorAttributeToFloat("ambient_occlusion_intensity", Description.Variations, 1.0f));
-
-    Camera->SetAORadius(
-        RetrieveActorAttributeToFloat("ambient_occlusion_radius", Description.Variations, 40.0f));
+        FVector4(ColorContrast.X, ColorContrast.Y, ColorContrast.Z, 1.0f));
 
     // Temporal comments until FVector is implemented in clientside
-    auto ColorGamma = FLinearColor(RetrieveActorAttributeToColor("color_gamma", Description.Variations, FLinearColor(1.1f, 1.1f, 1.1f).ToFColorSRGB()));
+    FVector ColorGamma = FVector(RetrieveActorAttributeToVector("color_gamma", Description.Variations, FVector( 1.2f, 1.2f, 1.2f )));
     Camera->SetColorGamma(
-        FVector4(ColorGamma.R, ColorGamma.G, ColorGamma.B, 1.0f));
+        FVector4(ColorGamma.X, ColorGamma.Y, ColorGamma.Z, 1.0f));
 
     auto HighlightsGamma = FLinearColor(RetrieveActorAttributeToColor("highlights_gamma", Description.Variations, FLinearColor(0.5f, 0.5, 0.5f).ToFColorSRGB()));
     Camera->SetHighlightsGamma(
@@ -1959,10 +1811,10 @@ void UActorBlueprintFunctionLibrary::SetCamera(
         RetrieveActorAttributeToFloat("tone_curve_amount", Description.Variations, 1.0f));
 
     Camera->SetSceneColorTint(
-        RetrieveActorAttributeToColor("scene_color_tint", Description.Variations, FLinearColor(0.972549f, 0.921569f, 0.796079f).ToFColorSRGB()));
+        RetrieveActorAttributeToColor("scene_color_tint", Description.Variations, FLinearColor(0.785339f, 0.879092f, 0.93125f).ToFColorSRGB()));
 
     Camera->SetVignetteIntensity(
-        RetrieveActorAttributeToFloat("vignette_intensity", Description.Variations, 0.4f));
+        RetrieveActorAttributeToFloat("vignette_intensity", Description.Variations, 0.7f));
   }
 }
 
@@ -1972,17 +1824,17 @@ void UActorBlueprintFunctionLibrary::SetCamera(
 {
   CARLA_ABFL_CHECK_ACTOR(Camera);
   Camera->SetFloatShaderParameter(0, TEXT("CircleFalloff_NState"),
-                                  RetrieveActorAttributeToFloat("lens_circle_falloff", Description.Variations, 5.0f));
+      RetrieveActorAttributeToFloat("lens_circle_falloff", Description.Variations, 5.0f));
   Camera->SetFloatShaderParameter(0, TEXT("CircleMultiplier_NState"),
-                                  RetrieveActorAttributeToFloat("lens_circle_multiplier", Description.Variations, 0.0f));
+      RetrieveActorAttributeToFloat("lens_circle_multiplier", Description.Variations, 0.0f));
   Camera->SetFloatShaderParameter(0, TEXT("K_NState"),
-                                  RetrieveActorAttributeToFloat("lens_k", Description.Variations, -1.0f));
+      RetrieveActorAttributeToFloat("lens_k", Description.Variations, -1.0f));
   Camera->SetFloatShaderParameter(0, TEXT("kcube"),
-                                  RetrieveActorAttributeToFloat("lens_kcube", Description.Variations, 0.0f));
+      RetrieveActorAttributeToFloat("lens_kcube", Description.Variations, 0.0f));
   Camera->SetFloatShaderParameter(0, TEXT("XSize_NState"),
-                                  RetrieveActorAttributeToFloat("lens_x_size", Description.Variations, 0.08f));
+      RetrieveActorAttributeToFloat("lens_x_size", Description.Variations, 0.08f));
   Camera->SetFloatShaderParameter(0, TEXT("YSize_NState"),
-                                  RetrieveActorAttributeToFloat("lens_y_size", Description.Variations, 0.08f));
+      RetrieveActorAttributeToFloat("lens_y_size", Description.Variations, 0.08f));
 }
 
 void UActorBlueprintFunctionLibrary::SetLidar(
@@ -2026,7 +1878,7 @@ void UActorBlueprintFunctionLibrary::SetGnss(
   if (Description.Variations.Contains("noise_seed"))
   {
     Gnss->SetSeed(
-        RetrieveActorAttributeToInt("noise_seed", Description.Variations, 0));
+      RetrieveActorAttributeToInt("noise_seed", Description.Variations, 0));
   }
   else
   {
@@ -2062,17 +1914,20 @@ void UActorBlueprintFunctionLibrary::SetIMU(
     IMU->SetSeed(IMU->GetRandomEngine()->GenerateRandomSeed());
   }
 
-  IMU->SetAccelerationStandardDeviation({RetrieveActorAttributeToFloat("noise_accel_stddev_x", Description.Variations, 0.0f),
-                                         RetrieveActorAttributeToFloat("noise_accel_stddev_y", Description.Variations, 0.0f),
-                                         RetrieveActorAttributeToFloat("noise_accel_stddev_z", Description.Variations, 0.0f)});
+  IMU->SetAccelerationStandardDeviation({
+      RetrieveActorAttributeToFloat("noise_accel_stddev_x", Description.Variations, 0.0f),
+      RetrieveActorAttributeToFloat("noise_accel_stddev_y", Description.Variations, 0.0f),
+      RetrieveActorAttributeToFloat("noise_accel_stddev_z", Description.Variations, 0.0f)});
 
-  IMU->SetGyroscopeStandardDeviation({RetrieveActorAttributeToFloat("noise_gyro_stddev_x", Description.Variations, 0.0f),
-                                      RetrieveActorAttributeToFloat("noise_gyro_stddev_y", Description.Variations, 0.0f),
-                                      RetrieveActorAttributeToFloat("noise_gyro_stddev_z", Description.Variations, 0.0f)});
+  IMU->SetGyroscopeStandardDeviation({
+      RetrieveActorAttributeToFloat("noise_gyro_stddev_x", Description.Variations, 0.0f),
+      RetrieveActorAttributeToFloat("noise_gyro_stddev_y", Description.Variations, 0.0f),
+      RetrieveActorAttributeToFloat("noise_gyro_stddev_z", Description.Variations, 0.0f)});
 
-  IMU->SetGyroscopeBias({RetrieveActorAttributeToFloat("noise_gyro_bias_x", Description.Variations, 0.0f),
-                         RetrieveActorAttributeToFloat("noise_gyro_bias_y", Description.Variations, 0.0f),
-                         RetrieveActorAttributeToFloat("noise_gyro_bias_z", Description.Variations, 0.0f)});
+  IMU->SetGyroscopeBias({
+      RetrieveActorAttributeToFloat("noise_gyro_bias_x", Description.Variations, 0.0f),
+      RetrieveActorAttributeToFloat("noise_gyro_bias_y", Description.Variations, 0.0f),
+      RetrieveActorAttributeToFloat("noise_gyro_bias_z", Description.Variations, 0.0f)});
 }
 
 void UActorBlueprintFunctionLibrary::SetRadar(
@@ -2085,7 +1940,7 @@ void UActorBlueprintFunctionLibrary::SetRadar(
   if (Description.Variations.Contains("noise_seed"))
   {
     Radar->SetSeed(
-        RetrieveActorAttributeToInt("noise_seed", Description.Variations, 0));
+      RetrieveActorAttributeToInt("noise_seed", Description.Variations, 0));
   }
   else
   {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.cpp
@@ -26,8 +26,7 @@ static int SCENE_CAPTURE_COUNTER = 0u;
 // =============================================================================
 
 // Local namespace to avoid name collisions on unit builds.
-namespace SceneCaptureSensor_local_ns
-{
+namespace SceneCaptureSensor_local_ns {
 
   static void SetCameraDefaultOverrides(USceneCaptureComponent2D &CaptureComponent2D);
 
@@ -45,7 +44,7 @@ namespace SceneCaptureSensor_local_ns
 // =============================================================================
 
 ASceneCaptureSensor::ASceneCaptureSensor(const FObjectInitializer &ObjectInitializer)
-    : Super(ObjectInitializer)
+  : Super(ObjectInitializer)
 {
   PrimaryActorTick.bCanEverTick = true;
   PrimaryActorTick.TickGroup = TG_PrePhysics;
@@ -99,52 +98,10 @@ float ASceneCaptureSensor::GetFOVAngle() const
   return CaptureComponent2D->FOVAngle;
 }
 
-float ASceneCaptureSensor::GetDirtMaskIntensity() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.BloomDirtMaskIntensity;
-}
-
 void ASceneCaptureSensor::SetExposureMethod(EAutoExposureMethod Method)
 {
   check(CaptureComponent2D != nullptr);
   CaptureComponent2D->PostProcessSettings.AutoExposureMethod = Method;
-}
-
-void ASceneCaptureSensor::SetLocalExposureMethod(ELocalExposureMethod Method)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.LocalExposureMethod = Method;
-}
-
-ELocalExposureMethod ASceneCaptureSensor::GetLocalExposureMethod() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.LocalExposureMethod;
-}
-
-void ASceneCaptureSensor::SetBloomConvolutionTexture(UTexture2D *Texture)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.BloomConvolutionTexture = Texture;
-}
-
-void ASceneCaptureSensor::SetDirtMaskIntensity(float Intensity)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.BloomDirtMaskIntensity = Intensity;
-}
-
-EBloomMethod ASceneCaptureSensor::GetBloomMethod() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.BloomMethod;
-}
-
-UTexture2D *ASceneCaptureSensor::GetBloomKernelTexture() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.BloomConvolutionTexture;
 }
 
 EAutoExposureMethod ASceneCaptureSensor::GetExposureMethod() const
@@ -447,12 +404,6 @@ float ASceneCaptureSensor::GetLensFlareIntensity() const
   return CaptureComponent2D->PostProcessSettings.LensFlareIntensity;
 }
 
-void ASceneCaptureSensor::SetBloomMethod(EBloomMethod Method)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.BloomMethod = Method;
-}
-
 void ASceneCaptureSensor::SetBloomIntensity(float Intensity)
 {
   check(CaptureComponent2D != nullptr);
@@ -525,30 +476,6 @@ FVector4 ASceneCaptureSensor::GetColorSaturation() const
   return CaptureComponent2D->PostProcessSettings.ColorSaturation;
 }
 
-void ASceneCaptureSensor::SetColorSaturationMidtones(FVector4 ColorSaturation)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.ColorSaturationMidtones = ColorSaturation;
-}
-
-FVector4 ASceneCaptureSensor::GetColorSaturationMidtones() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.ColorSaturationMidtones;
-}
-
-void ASceneCaptureSensor::SetColorSaturationHighlights(FVector4 ColorSaturation)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.ColorSaturationHighlights = ColorSaturation;
-}
-
-FVector4 ASceneCaptureSensor::GetColorSaturationHighlights() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.ColorSaturationHighlights;
-}
-
 void ASceneCaptureSensor::SetColorContrast(FVector4 ColorContrast)
 {
   check(CaptureComponent2D != nullptr);
@@ -559,30 +486,6 @@ FVector4 ASceneCaptureSensor::GetColorContrast() const
 {
   check(CaptureComponent2D != nullptr);
   return CaptureComponent2D->PostProcessSettings.ColorContrast;
-}
-
-void ASceneCaptureSensor::SetColorContrastMidtones(FVector4 ColorContrast)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.ColorContrastMidtones = ColorContrast;
-}
-
-FVector4 ASceneCaptureSensor::GetColorContrastMidtones() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.ColorContrastMidtones;
-}
-
-void ASceneCaptureSensor::SetColorContrastHighlights(FVector4 ColorContrast)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.ColorContrastHighlights = ColorContrast;
-}
-
-FVector4 ASceneCaptureSensor::GetColorContrastHighlights() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.ColorContrastHighlights;
 }
 
 void ASceneCaptureSensor::SetColorGamma(FVector4 ColorGamma)
@@ -645,78 +548,6 @@ float ASceneCaptureSensor::GetVignetteIntensity() const
   return CaptureComponent2D->PostProcessSettings.VignetteIntensity;
 }
 
-void ASceneCaptureSensor::SetGlobalGain(FVector4 Gain)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.ColorGain = Gain;
-}
-
-FVector4 ASceneCaptureSensor::GetGlobalGain() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.ColorGain;
-}
-
-void ASceneCaptureSensor::SetBlueCorrection(float Val)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.BlueCorrection = Val;
-}
-
-float ASceneCaptureSensor::GetBlueCorrection() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.BlueCorrection;
-}
-
-void ASceneCaptureSensor::SetDetailStrength(float Val)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.LocalExposureDetailStrength = Val;
-}
-
-float ASceneCaptureSensor::GetDetailStrength() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.LocalExposureDetailStrength;
-}
-
-void ASceneCaptureSensor::SetFilmGrainIntensity(float Val)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.FilmGrainIntensity = Val;
-}
-
-float ASceneCaptureSensor::GetFilmGrainIntensity() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.FilmGrainIntensity;
-}
-
-void ASceneCaptureSensor::SetAOIntensity(float Intensity)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.AmbientOcclusionIntensity = Intensity;
-}
-
-float ASceneCaptureSensor::GetAOIntensity() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.AmbientOcclusionIntensity;
-}
-
-void ASceneCaptureSensor::SetAORadius(float Radius)
-{
-  check(CaptureComponent2D != nullptr);
-  CaptureComponent2D->PostProcessSettings.AmbientOcclusionRadius = Radius;
-}
-
-float ASceneCaptureSensor::GetAORadius() const
-{
-  check(CaptureComponent2D != nullptr);
-  return CaptureComponent2D->PostProcessSettings.AmbientOcclusionRadius;
-}
-
 void ASceneCaptureSensor::SetHighlightContrastScale(float HighlightContrastScale)
 {
   check(CaptureComponent2D != nullptr);
@@ -742,38 +573,22 @@ float ASceneCaptureSensor::GetShadowContrastScale() const
 }
 
 void ASceneCaptureSensor::UpdatePostProcessConfig(
-    FPostProcessConfig &InOutPostProcessConfig)
+    FPostProcessConfig& InOutPostProcessConfig)
 {
 }
 
-bool ASceneCaptureSensor::ApplyPostProcessVolumeToSensor(APostProcessVolume *Origin, ASceneCaptureSensor *Dest, bool bOverrideCurrentCamera)
+bool ASceneCaptureSensor::ApplyPostProcessVolumeToSensor(APostProcessVolume* Origin, ASceneCaptureSensor* Dest, bool bOverrideCurrentCamera)
 {
-  if (!IsValid(Origin) || !IsValid(Dest))
+  if(!IsValid(Origin) || !IsValid(Dest))
   {
     return false;
   }
 
-  if (!bOverrideCurrentCamera)
+  if(!bOverrideCurrentCamera)
   {
-    // Cache postprocesssettings
+    //Cache postprocesssettings
     float CacheGamma = Dest->GetTargetGamma();
     EAutoExposureMethod CacheAutoExposureMethod = Dest->GetExposureMethod();
-    EBloomMethod CacheBloomMethod = Dest->GetBloomMethod();
-    UTexture2D *CacheBloomConvolutionTexture = Dest->GetBloomKernelTexture();
-    ELocalExposureMethod CacheLocalExposureMethod = Dest->GetLocalExposureMethod();
-    FVector4 CacheColorSaturation = Dest->GetColorSaturation();
-    FVector4 CacheColorSaturationMidtones = Dest->GetColorSaturationMidtones();
-    FVector4 CacheColorSaturationHighlights = Dest->GetColorSaturationHighlights();
-    FVector4 CacheColorContrast = Dest->GetColorContrast();
-    FVector4 CacheColorContrastMidtones = Dest->GetColorContrastMidtones();
-    FVector4 CacheColorContrastHighlights = Dest->GetColorContrastHighlights();
-    float CacheDetailStrength = Dest->GetDetailStrength();
-    float CacheBlueCorrection = Dest->GetBlueCorrection();
-    float CacheAmbientOcclusionIntensity = Dest->GetAOIntensity();
-    float CacheAmbientOcclusionRadius = Dest->GetAORadius();
-    float CacheFilmGrainIntensity = Dest->GetFilmGrainIntensity();
-    float CacheDirtIntensity = Dest->GetDirtMaskIntensity();
-    FVector4 CacheGain = Dest->GetGlobalGain();
     float CacheEC = Dest->GetExposureCompensation();
     float CacheSS = Dest->GetShutterSpeed();
     float CacheISO = Dest->GetISO();
@@ -804,23 +619,7 @@ bool ASceneCaptureSensor::ApplyPostProcessVolumeToSensor(APostProcessVolume *Ori
     float CacheCAO = Dest->GetChromAberrOffset();
 
     Dest->CaptureComponent2D->PostProcessSettings = Origin->Settings;
-
-    Dest->SetLocalExposureMethod(CacheLocalExposureMethod);
-    Dest->SetColorSaturation(CacheColorSaturation);
-    Dest->SetColorSaturationMidtones(CacheColorSaturationMidtones);
-    Dest->SetColorSaturationHighlights(CacheColorSaturationHighlights);
-    Dest->SetColorContrast(CacheColorContrast);
-    Dest->SetColorContrastMidtones(CacheColorContrastMidtones);
-    Dest->SetColorContrastHighlights(CacheColorContrastHighlights);
-    Dest->SetAOIntensity(CacheAmbientOcclusionIntensity);
-    Dest->SetAORadius(CacheAmbientOcclusionRadius);
-    Dest->SetBloomMethod(CacheBloomMethod);
-    Dest->SetBloomConvolutionTexture(CacheBloomConvolutionTexture);
-    Dest->SetDetailStrength(CacheDetailStrength);
-    Dest->SetBlueCorrection(CacheBlueCorrection);
-    Dest->SetFilmGrainIntensity(CacheFilmGrainIntensity);
-    Dest->SetDirtMaskIntensity(CacheDirtIntensity);
-    Dest->SetGlobalGain(CacheGain);
+  
     Dest->SetTargetGamma(CacheGamma);
     Dest->SetExposureMethod(CacheAutoExposureMethod);
     Dest->SetExposureCompensation(CacheEC);
@@ -860,8 +659,7 @@ bool ASceneCaptureSensor::ApplyPostProcessVolumeToSensor(APostProcessVolume *Ori
   return true;
 }
 
-void ASceneCaptureSensor::EnqueueRenderSceneImmediate()
-{
+void ASceneCaptureSensor::EnqueueRenderSceneImmediate() {
   TRACE_CPUPROFILER_EVENT_SCOPE(ASceneCaptureSensor::EnqueueRenderSceneImmediate);
   // Creates an snapshot of the scene, requieres bCaptureEveryFrame = false.
 #ifdef CARLA_HAS_GBUFFER_API
@@ -918,13 +716,13 @@ void ASceneCaptureSensor::BeginPlay()
 
   if (ImageWidth < 1920 || ImageHeight < 1080)
     CaptureComponent2D->ShowFlags.SetMotionBlur(false);
-
+  
   // This ensures the camera is always spawning the raindrops in case the
   // weather was previously set to have rain.
   auto Weather = GetEpisode().GetWeather();
   if (Weather != nullptr)
     Weather->NotifyWeather(this);
-
+  
   Super::BeginPlay();
 }
 
@@ -957,121 +755,109 @@ void ASceneCaptureSensor::EndPlay(const EEndPlayReason::Type EndPlayReason)
 
 #ifdef CARLA_HAS_GBUFFER_API
 
-constexpr const TCHAR *GBufferNames[] =
-    {
-        TEXT("SceneColor"),
-        TEXT("SceneDepth"),
-        TEXT("SceneStencil"),
-        TEXT("GBufferA"),
-        TEXT("GBufferB"),
-        TEXT("GBufferC"),
-        TEXT("GBufferD"),
-        TEXT("GBufferE"),
-        TEXT("GBufferF"),
-        TEXT("Velocity"),
-        TEXT("SSAO"),
-        TEXT("CustomDepth"),
-        TEXT("CustomStencil"),
+constexpr const TCHAR* GBufferNames[] =
+{
+  TEXT("SceneColor"),
+  TEXT("SceneDepth"),
+  TEXT("SceneStencil"),
+  TEXT("GBufferA"),
+  TEXT("GBufferB"),
+  TEXT("GBufferC"),
+  TEXT("GBufferD"),
+  TEXT("GBufferE"),
+  TEXT("GBufferF"),
+  TEXT("Velocity"),
+  TEXT("SSAO"),
+  TEXT("CustomDepth"),
+  TEXT("CustomStencil"),
 };
 
 template <EGBufferTextureID ID, typename T>
-static void CheckGBufferStream(T &GBufferStream, FGBufferRequest &GBuffer)
+static void CheckGBufferStream(T& GBufferStream, FGBufferRequest& GBuffer)
 {
-  GBufferStream.bIsUsed = GBufferStream.Stream.AreClientsListening();
-  if (GBufferStream.bIsUsed)
-    GBuffer.MarkAsRequested(ID);
+    GBufferStream.bIsUsed = GBufferStream.Stream.AreClientsListening();
+    if (GBufferStream.bIsUsed)
+        GBuffer.MarkAsRequested(ID);
 }
 
 static uint64 Prior = 0;
 
 void ASceneCaptureSensor::CaptureSceneExtended()
 {
-  auto GBufferPtr = MakeUnique<FGBufferRequest>();
-  auto &GBuffer = *GBufferPtr;
+    auto GBufferPtr = MakeUnique<FGBufferRequest>();
+    auto& GBuffer = *GBufferPtr;
 
-  CheckGBufferStream<EGBufferTextureID::SceneColor>(CameraGBuffers.SceneColor, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::SceneDepth>(CameraGBuffers.SceneDepth, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::SceneStencil>(CameraGBuffers.SceneStencil, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::GBufferA>(CameraGBuffers.GBufferA, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::GBufferB>(CameraGBuffers.GBufferB, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::GBufferC>(CameraGBuffers.GBufferC, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::GBufferD>(CameraGBuffers.GBufferD, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::GBufferE>(CameraGBuffers.GBufferE, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::GBufferF>(CameraGBuffers.GBufferF, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::Velocity>(CameraGBuffers.Velocity, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::SSAO>(CameraGBuffers.SSAO, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::CustomDepth>(CameraGBuffers.CustomDepth, GBuffer);
-  CheckGBufferStream<EGBufferTextureID::CustomStencil>(CameraGBuffers.CustomStencil, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::SceneColor>(CameraGBuffers.SceneColor, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::SceneDepth>(CameraGBuffers.SceneDepth, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::SceneStencil>(CameraGBuffers.SceneStencil, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::GBufferA>(CameraGBuffers.GBufferA, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::GBufferB>(CameraGBuffers.GBufferB, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::GBufferC>(CameraGBuffers.GBufferC, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::GBufferD>(CameraGBuffers.GBufferD, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::GBufferE>(CameraGBuffers.GBufferE, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::GBufferF>(CameraGBuffers.GBufferF, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::Velocity>(CameraGBuffers.Velocity, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::SSAO>(CameraGBuffers.SSAO, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::CustomDepth>(CameraGBuffers.CustomDepth, GBuffer);
+    CheckGBufferStream<EGBufferTextureID::CustomStencil>(CameraGBuffers.CustomStencil, GBuffer);
 
-  if (GBufferPtr->DesiredTexturesMask == 0)
-  {
-    // Creates an snapshot of the scene, requieres bCaptureEveryFrame = false.
-    CaptureComponent2D->CaptureScene();
-    return;
-  }
+    if (GBufferPtr->DesiredTexturesMask == 0)
+    {
+        // Creates an snapshot of the scene, requieres bCaptureEveryFrame = false.
+        CaptureComponent2D->CaptureScene();
+        return;
+    }
 
-  if (Prior != GBufferPtr->DesiredTexturesMask)
-    UE_LOG(LogCarla, Verbose, TEXT("GBuffer selection changed (%llu)."), GBufferPtr->DesiredTexturesMask);
+    if (Prior != GBufferPtr->DesiredTexturesMask)
+        UE_LOG(LogCarla, Verbose, TEXT("GBuffer selection changed (%llu)."), GBufferPtr->DesiredTexturesMask);
 
-  Prior = GBufferPtr->DesiredTexturesMask;
-  GBufferPtr->OwningActor = CaptureComponent2D->GetViewOwner();
+    Prior = GBufferPtr->DesiredTexturesMask;
+    GBufferPtr->OwningActor = CaptureComponent2D->GetViewOwner();
 
 #define CARLA_GBUFFER_DISABLE_TAA // Temporarily disable TAA to avoid jitter.
 
 #ifdef CARLA_GBUFFER_DISABLE_TAA
-  bool bTAA = CaptureComponent2D->ShowFlags.TemporalAA;
-  if (bTAA)
-  {
-    CaptureComponent2D->ShowFlags.TemporalAA = false;
-  }
+    bool bTAA = CaptureComponent2D->ShowFlags.TemporalAA;
+    if (bTAA) {
+        CaptureComponent2D->ShowFlags.TemporalAA = false;
+    }
 #endif
 
-  CaptureComponent2D->CaptureSceneWithGBuffer(GBuffer);
+    CaptureComponent2D->CaptureSceneWithGBuffer(GBuffer);
 
 #ifdef CARLA_GBUFFER_DISABLE_TAA
-  if (bTAA)
-  {
-    CaptureComponent2D->ShowFlags.TemporalAA = true;
-  }
+    if (bTAA) {
+        CaptureComponent2D->ShowFlags.TemporalAA = true;
+    }
 #undef CARLA_GBUFFER_DISABLE_TAA
 #endif
 
-  AsyncTask(ENamedThreads::AnyHiPriThreadNormalTask, [this, GBuffer = MoveTemp(GBufferPtr)]() mutable
-            { SendGBufferTextures(*GBuffer); });
+    AsyncTask(ENamedThreads::AnyHiPriThreadNormalTask, [this, GBuffer = MoveTemp(GBufferPtr)]() mutable
+        {
+            SendGBufferTextures(*GBuffer);
+        });
 }
 
-void ASceneCaptureSensor::SendGBufferTextures(FGBufferRequest &GBuffer)
+void ASceneCaptureSensor::SendGBufferTextures(FGBufferRequest& GBuffer)
 {
-  SendGBufferTexturesInternal(*this, GBuffer);
+    SendGBufferTexturesInternal(*this, GBuffer);
 }
 
 #endif
+
+
 
 // =============================================================================
 // -- Local static functions implementations -----------------------------------
 // =============================================================================
 
-namespace SceneCaptureSensor_local_ns
-{
+namespace SceneCaptureSensor_local_ns {
 
   static void SetCameraDefaultOverrides(USceneCaptureComponent2D &CaptureComponent2D)
   {
     auto &PostProcessSettings = CaptureComponent2D.PostProcessSettings;
 
-    PostProcessSettings.bOverride_ColorSaturationMidtones = true;
-    PostProcessSettings.bOverride_ColorContrastMidtones = true;
-    PostProcessSettings.bOverride_ColorSaturationHighlights = true;
-    PostProcessSettings.bOverride_ColorContrastHighlights = true;
     PostProcessSettings.bOverride_AutoExposureMethod = true;
-    PostProcessSettings.bOverride_ColorGain = true;
-    PostProcessSettings.bOverride_LocalExposureMethod = true;
-    PostProcessSettings.bOverride_BlueCorrection = true;
-    PostProcessSettings.bOverride_FilmGrainIntensity = true;
-    PostProcessSettings.bOverride_AmbientOcclusionIntensity = true;
-    PostProcessSettings.bOverride_AmbientOcclusionRadius = true;
-    PostProcessSettings.bOverride_BloomMethod = true;
-    PostProcessSettings.bOverride_BloomDirtMaskIntensity = true;
-    PostProcessSettings.bOverride_BloomConvolutionTexture = true;
     PostProcessSettings.bOverride_AutoExposureBias = true;
     PostProcessSettings.bOverride_CameraShutterSpeed = true;
     PostProcessSettings.bOverride_CameraISO = true;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/SceneCaptureSensor.h
@@ -24,10 +24,13 @@
 
 #include "SceneCaptureSensor.generated.h"
 
+
+
 class UDrawFrustumComponent;
 class UStaticMeshComponent;
 class UTextureRenderTarget2D;
 class APostProcessVolume;
+
 
 struct FCameraGBufferUint8
 {
@@ -70,6 +73,8 @@ struct FCameraGBufferUint8
   FDataStream Stream;
 };
 
+
+
 struct FCameraGBufferFloat
 {
   /// Prevent this sensor to be spawned by users.
@@ -110,6 +115,8 @@ struct FCameraGBufferFloat
   FDataStream Stream;
 };
 
+
+
 /// Base class for sensors using a USceneCaptureComponent2D for rendering the
 /// scene. This class does not capture data, use
 /// `FPixelReader::SendPixelsInRenderThread<FColor>(*this)` in derived classes.
@@ -128,6 +135,7 @@ class CARLA_API ASceneCaptureSensor : public ASensor
   friend class FPixelReader2;
 
 public:
+
   ASceneCaptureSensor(const FObjectInitializer &ObjectInitializer);
 
   void Set(const FActorDescription &ActorDescription) override;
@@ -187,76 +195,16 @@ public:
   }
 
   UFUNCTION(BlueprintCallable)
-  void SetBloomMethod(EBloomMethod Method);
-
-  UFUNCTION(BlueprintCallable)
-  EBloomMethod GetBloomMethod() const;
-
-  UFUNCTION(BlueprintCallable)
-  FVector4 GetGlobalGain() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetGlobalGain(FVector4 Gain);
-
-  UFUNCTION(BlueprintCallable)
-  float GetBlueCorrection() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetBlueCorrection(float Val);
-
-  UFUNCTION(BlueprintCallable)
-  float GetDetailStrength() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetDetailStrength(float Val);
-
-  UFUNCTION(BlueprintCallable)
-  float GetFilmGrainIntensity() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetFilmGrainIntensity(float Val);
-
-  UFUNCTION(BlueprintCallable)
-  void SetAOIntensity(float Intensity);
-
-  UFUNCTION(BlueprintCallable)
-  float GetAOIntensity() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetAORadius(float Radius);
-
-  UFUNCTION(BlueprintCallable)
-  float GetAORadius() const;
-
-  UFUNCTION(BlueprintCallable)
   void SetExposureMethod(EAutoExposureMethod Method);
 
   UFUNCTION(BlueprintCallable)
   EAutoExposureMethod GetExposureMethod() const;
 
   UFUNCTION(BlueprintCallable)
-  void SetLocalExposureMethod(ELocalExposureMethod Method);
-
-  UFUNCTION(BlueprintCallable)
-  ELocalExposureMethod GetLocalExposureMethod() const;
-
-  UFUNCTION(BlueprintCallable)
-  UTexture2D *GetBloomKernelTexture() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetBloomConvolutionTexture(UTexture2D *Texture);
-
-  UFUNCTION(BlueprintCallable)
   void SetExposureCompensation(float Compensation);
 
   UFUNCTION(BlueprintCallable)
   float GetExposureCompensation() const;
-
-  UFUNCTION(BlueprintCallable)
-  float GetDirtMaskIntensity() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetDirtMaskIntensity(float Intensity);
 
   UFUNCTION(BlueprintCallable)
   void SetShutterSpeed(float Speed);
@@ -433,34 +381,10 @@ public:
   FVector4 GetColorSaturation() const;
 
   UFUNCTION(BlueprintCallable)
-  void SetColorSaturationMidtones(FVector4 ColorSaturation);
-
-  UFUNCTION(BlueprintCallable)
-  FVector4 GetColorSaturationMidtones() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetColorSaturationHighlights(FVector4 ColorSaturation);
-
-  UFUNCTION(BlueprintCallable)
-  FVector4 GetColorSaturationHighlights() const;
-
-  UFUNCTION(BlueprintCallable)
   void SetColorContrast(FVector4 ColorContrast);
 
   UFUNCTION(BlueprintCallable)
   FVector4 GetColorContrast() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetColorContrastMidtones(FVector4 ColorContrast);
-
-  UFUNCTION(BlueprintCallable)
-  FVector4 GetColorContrastMidtones() const;
-
-  UFUNCTION(BlueprintCallable)
-  void SetColorContrastHighlights(FVector4 ColorContrast);
-
-  UFUNCTION(BlueprintCallable)
-  FVector4 GetColorContrastHighlights() const;
 
   UFUNCTION(BlueprintCallable)
   void SetColorGamma(FVector4 ColorGamma);
@@ -505,7 +429,7 @@ public:
   float GetShadowContrastScale() const;
 
   virtual void UpdatePostProcessConfig(
-      FPostProcessConfig &InOutPostProcessConfig);
+    FPostProcessConfig& InOutPostProcessConfig);
 
   /// Use for debugging purposes only.
   UFUNCTION(BlueprintCallable)
@@ -539,8 +463,7 @@ public:
   void EnqueueRenderSceneImmediate();
 
   /// Blocks until the render thread has finished all it's tasks.
-  void WaitForRenderThreadToFinish()
-  {
+  void WaitForRenderThreadToFinish() {
     TRACE_CPUPROFILER_EVENT_SCOPE(ASceneCaptureSensor::WaitForRenderThreadToFinish);
     // FlushRenderingCommands();
   }
@@ -563,13 +486,13 @@ public:
   } CameraGBuffers;
 
   UFUNCTION(BlueprintCallable)
-  static bool ApplyPostProcessVolumeToSensor(APostProcessVolume *Origin, ASceneCaptureSensor *Dest, bool bOverrideCurrentCamera = false);
-
+  static bool ApplyPostProcessVolumeToSensor(APostProcessVolume* Origin, ASceneCaptureSensor* Dest, bool bOverrideCurrentCamera = false);
 protected:
+
   void CaptureSceneExtended();
 
 #ifdef CARLA_HAS_GBUFFER_API
-  virtual void SendGBufferTextures(FGBufferRequest &GBuffer);
+  virtual void SendGBufferTextures(FGBufferRequest& GBuffer);
 #endif
 
   virtual void BeginPlay() override;
@@ -609,39 +532,40 @@ protected:
   bool bEnable16BitFormat = false;
 
 private:
+
 #ifdef CARLA_HAS_GBUFFER_API
   template <
-      typename SensorT,
-      typename CameraGBufferT>
+    typename SensorT,
+    typename CameraGBufferT>
   static void SendGBuffer(
-      SensorT &Self,
-      CameraGBufferT &CameraGBuffer,
-      FGBufferRequest &GBufferData,
+      SensorT& Self,
+      CameraGBufferT& CameraGBuffer,
+      FGBufferRequest& GBufferData,
       EGBufferTextureID TextureID)
   {
-    using PixelType = typename std::conditional<
+      using PixelType = typename std::conditional<
         std::is_same<std::remove_reference_t<CameraGBufferT>, FCameraGBufferUint8>::value,
         FColor,
         FLinearColor>::type;
-    FIntPoint ViewSize;
-    TArray<PixelType> Pixels;
-    if (GBufferData.WaitForTextureTransfer(TextureID))
-    {
-      TRACE_CPUPROFILER_EVENT_SCOPE_STR("GBuffer Decode");
-      void *PixelData;
-      int32 SourcePitch;
-      FIntPoint SourceExtent;
-      GBufferData.MapTextureData(
+      FIntPoint ViewSize;
+      TArray<PixelType> Pixels;
+      if (GBufferData.WaitForTextureTransfer(TextureID))
+      {
+        TRACE_CPUPROFILER_EVENT_SCOPE_STR("GBuffer Decode");
+        void* PixelData;
+        int32 SourcePitch;
+        FIntPoint SourceExtent;
+        GBufferData.MapTextureData(
           TextureID,
           PixelData,
           SourcePitch,
           SourceExtent);
-      auto Format = GBufferData.Readbacks[(size_t)TextureID]->GetFormat();
-      ViewSize = GBufferData.ViewRect.Size();
-      Pixels.AddUninitialized(ViewSize.X * ViewSize.Y);
-      FReadSurfaceDataFlags Flags = {};
-      Flags.SetLinearToGamma(true);
-      ImageUtil::DecodePixelsByFormat(
+        auto Format = GBufferData.Readbacks[(size_t)TextureID]->GetFormat();
+        ViewSize = GBufferData.ViewRect.Size();
+        Pixels.AddUninitialized(ViewSize.X * ViewSize.Y);
+        FReadSurfaceDataFlags Flags = {};
+        Flags.SetLinearToGamma(true);
+        ImageUtil::DecodePixelsByFormat(
           PixelData,
           SourcePitch,
           SourceExtent,
@@ -649,27 +573,26 @@ private:
           Format,
           Flags,
           Pixels);
-      GBufferData.UnmapTextureData(TextureID);
-    }
-    else
-    {
-      ViewSize = GBufferData.ViewRect.Size();
-      Pixels.SetNum(ViewSize.X * ViewSize.Y);
-      for (auto &Pixel : Pixels)
-        Pixel = PixelType::Black;
-    }
-    auto GBufferStream = CameraGBuffer.GetDataStream(Self);
-    auto Buffer = GBufferStream.PopBufferFromPool();
-    Buffer.copy_from(
-        carla::sensor::SensorRegistry::get<CameraGBufferT *>::type::header_offset,
+        GBufferData.UnmapTextureData(TextureID);
+      }
+      else
+      {
+        ViewSize = GBufferData.ViewRect.Size();
+        Pixels.SetNum(ViewSize.X * ViewSize.Y);
+        for (auto& Pixel : Pixels)
+          Pixel = PixelType::Black;
+      }
+      auto GBufferStream = CameraGBuffer.GetDataStream(Self);
+      auto Buffer = GBufferStream.PopBufferFromPool();
+      Buffer.copy_from(
+        carla::sensor::SensorRegistry::get<CameraGBufferT*>::type::header_offset,
         Pixels);
-    if (Buffer.empty())
-    {
-      return;
-    }
-    SCOPE_CYCLE_COUNTER(STAT_CarlaSensorStreamSend);
-    TRACE_CPUPROFILER_EVENT_SCOPE_STR("Stream Send");
-    GBufferStream.SerializeAndSend(
+      if (Buffer.empty()) {
+        return;
+      }
+      SCOPE_CYCLE_COUNTER(STAT_CarlaSensorStreamSend);
+      TRACE_CPUPROFILER_EVENT_SCOPE_STR("Stream Send");
+      GBufferStream.SerializeAndSend(
         CameraGBuffer,
         std::move(Buffer),
         ViewSize.X,
@@ -679,17 +602,17 @@ private:
 #endif
 
 protected:
+
 #ifdef CARLA_HAS_GBUFFER_API
   template <typename T>
-  void SendGBufferTexturesInternal(T &Self, FGBufferRequest &GBufferData)
+  void SendGBufferTexturesInternal(T& Self, FGBufferRequest& GBufferData)
   {
     for (size_t i = 0; i != FGBufferRequest::TextureCount; ++i)
     {
-      if ((GBufferData.DesiredTexturesMask & (UINT64_C(1) << i)) == 0)
-      {
+      if ((GBufferData.DesiredTexturesMask & (UINT64_C(1) << i)) == 0) {
         continue;
       }
-      auto &C = CameraGBuffers;
+      auto& C = CameraGBuffers;
       EGBufferTextureID ID = (EGBufferTextureID)i;
       switch (ID)
       {
@@ -733,9 +656,10 @@ protected:
         SendGBuffer(Self, C.CustomStencil, GBufferData, ID);
         break;
       default:
-        abort();
+          abort();
       }
     }
   }
 #endif
+
 };


### PR DESCRIPTION
This removes changes made in https://github.com/carla-simulator/carla/pull/9024 as they caused a very dark camera sensor output.

> [!WARNING]
> This probably not **the way** to fix this issue, but it is the fastest.
> In future probably a better fix should be found and the changes removed here should be brought back.

### Table with comparison images taken directly from Python API
| Camera image before | Camera image after |
| --- | --- |
| <img width="1920" height="1080" alt="000403" src="https://github.com/user-attachments/assets/c775d95a-c718-40ca-93e0-48dadce243ee" /> | <img width="1920" height="1080" alt="093583" src="https://github.com/user-attachments/assets/069979e0-f2c1-403f-9810-5b474dcb65a2" /> |

RViz camera sensor data view:
<img width="459" height="287" alt="image" src="https://github.com/user-attachments/assets/2dbd9ea2-230d-4d00-a956-53a2b1c069bd" />
