### PR TITLE
Match ROS coordinate system when publishing IMU

### DIFF
--- a/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaIMUPublisher.cpp
@@ -160,14 +160,14 @@ namespace ros2 {
     const float ay = *pAccelerometer++;
     const float az = *pAccelerometer++;
     linear_acceleration.x(ax);
-    linear_acceleration.y(ay);
+    linear_acceleration.y(-ay);
     linear_acceleration.z(az);
     const float gx = *pGyroscope++;
     const float gy = *pGyroscope++;
     const float gz = *pGyroscope++;
     gyroscope.x(gx);
-    gyroscope.y(gy);
-    gyroscope.z(gz);
+    gyroscope.y(-gy);  // Invert pitch and yaw to match ROS
+    gyroscope.z(-gz);
 
     builtin_interfaces::msg::Time time;
     time.sec(seconds);


### PR DESCRIPTION
Converts IMU data from UE coordinate system (left-handed) to ROS2 coordinate system (right-handed) before publishing