### PR TITLE
Use global ROS time when publishing Ego status

### DIFF
--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -1049,11 +1049,11 @@ void ROS2::ProcessDataFromCollisionSensor(
 }
 
 void ROS2::ProcessDataFromStatusSensor(
-  uint64_t sensor_type, 
-  carla::streaming::detail::stream_id_type stream_id, 
-  const carla::geom::Transform sensor_transform, 
-  const sensor::s11n::VehicleStatusData data, 
-  void *vehicle_actor, 
+  uint64_t sensor_type,
+  carla::streaming::detail::stream_id_type stream_id,
+  const carla::geom::Transform sensor_transform,
+  const sensor::s11n::VehicleStatusData data,
+  void *vehicle_actor,
   void *actor)
 {
   // This callback is only for the Ego vehicle
@@ -1144,8 +1144,7 @@ void ROS2::ProcessDataFromStatusSensor(
 
   _autoware_publisher->SetHazardLights(is_hazard_lights_on);
 
-  const auto [seconds, nanoseconds] = Carla2RosTime(data.timestamp);
-  _autoware_publisher->Publish(seconds, nanoseconds);
+  _autoware_publisher->Publish(_seconds, _nanoseconds);
 
   // Debug
   if constexpr (false) {


### PR DESCRIPTION
## Description
Use global ROS time for stamp when publishing Ego status.


## Background
Without this fix, clock and each status topic would publish **at the same time** messages with different time stamp, e.g.:
- `/clock` topic
  ```log
  sec: 63
  nanosec: 753953936
  ```
- `/vehicle/status/steering_status` topic stamp
  ```log
  sec: 62
  nanosec: 854392346
  ```

## Issue solved
The above discrepancy would cause the following error and the _floating_ localization problem shown on the video below.

Error:
```log
[autoware_gyro_odometer_node-40] [ERROR 1758754970.199127022] [localization.twist_estimator.gyro_odometer]: Vehicle twist msg is timeout. vehicle_twist_dt: 0.879561591[sec], tolerance 0.2[sec] (concat_gyro_and_odometer() at /robo-srv-014-storage-001/tier4/carla-autoware/autoware/src/core/autoware_core/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp:146)
```

Video:

https://github.com/user-attachments/assets/5b382dea-492f-4622-980e-cab3192b8c46

**After this fix, the _floating_ localization issue does not happen.**
