### PR TITLE
Feature: Flatten steering curve of Ego

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorDispatcher.cpp
@@ -215,6 +215,7 @@ FCarlaActor* UActorDispatcher::RegisterActor(
       {
         if (Attr.Key == "role_name" && (Attr.Value.Value == "hero" || Attr.Value.Value == "ego"))
         {
+          ActorROS2Handler::FlattenSteeringCurve(&Actor);
           ROS2->AddActorCallback(static_cast<void*>(&Actor), RosName, [RosName](void *Actor, carla::ros2::ROS2CallbackData Data) -> void
           {
             AActor *UEActor = reinterpret_cast<AActor *>(Actor);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
@@ -74,7 +74,7 @@ bool ActorROS2Handler::FlattenSteeringCurve(AActor * Actor)
   VehiclePhysicsControl.SteeringCurve.AddKey(120.f, 1.f);
 
   Vehicle->ApplyVehiclePhysicsControl(VehiclePhysicsControl);
-  std::cerr << "Resetting SteeringCurve!" << std::endl;
+  UE_LOG(LogCarla, Log, TEXT("Resetting SteeringCurve!"));
 
   return true;
 }

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
@@ -58,3 +58,28 @@ void ActorROS2Handler::operator()(carla::ros2::MessageControl Message)
   // FString ROSMessage = Message.message;
   // UE_LOG(LogCarla, Warning, TEXT("ROS2 Message received: %s"), *ROSMessage);
 }
+
+bool ActorROS2Handler::FlattenSteeringCurve(AActor * Actor)
+{
+  if (!Actor) return false;
+
+  ACarlaWheeledVehicle * const Vehicle = Cast<ACarlaWheeledVehicle>(Actor);
+  if (!Vehicle) return false;
+
+  UChaosWheeledVehicleMovementComponent * const MovementComponent = Vehicle->GetChaosWheeledVehicleMovementComponent();
+  if (!MovementComponent) return false;
+
+  FRichCurve * const Curve = MovementComponent->SteeringSetup.SteeringCurve.GetRichCurve();
+  if (!Curve) return false;
+
+  /// @note Flatten steering curve to be always 1.0 to properly map wheel angle to steering at all speeds
+  Curve->Reset();
+  Curve->AddKey(0.0f,   1.0f);
+  Curve->AddKey(40.0f,  1.0f);
+  Curve->AddKey(80.0f,  1.0f);
+  Curve->AddKey(120.0f, 1.0f);
+  Curve->AutoSetTangents();
+  std::cerr << "Resetting SteeringCurve!" << std::endl;
+
+  return true;
+}

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
@@ -66,19 +66,14 @@ bool ActorROS2Handler::FlattenSteeringCurve(AActor * Actor)
   ACarlaWheeledVehicle * const Vehicle = Cast<ACarlaWheeledVehicle>(Actor);
   if (!Vehicle) return false;
 
-  UChaosWheeledVehicleMovementComponent * const MovementComponent = Vehicle->GetChaosWheeledVehicleMovementComponent();
-  if (!MovementComponent) return false;
-
-  FRichCurve * const Curve = MovementComponent->SteeringSetup.SteeringCurve.GetRichCurve();
-  if (!Curve) return false;
+  auto VehiclePhysicsControl = Vehicle->GetVehiclePhysicsControl();
 
   /// @note Flatten steering curve to be always 1.0 to properly map wheel angle to steering at all speeds
-  Curve->Reset();
-  Curve->AddKey(0.0f,   1.0f);
-  Curve->AddKey(40.0f,  1.0f);
-  Curve->AddKey(80.0f,  1.0f);
-  Curve->AddKey(120.0f, 1.0f);
-  Curve->AutoSetTangents();
+  VehiclePhysicsControl.SteeringCurve.Reset();
+  VehiclePhysicsControl.SteeringCurve.AddKey(0.f,   1.f);
+  VehiclePhysicsControl.SteeringCurve.AddKey(120.f, 1.f);
+
+  Vehicle->ApplyVehiclePhysicsControl(VehiclePhysicsControl);
   std::cerr << "Resetting SteeringCurve!" << std::endl;
 
   return true;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
@@ -10,10 +10,10 @@
 
 void ActorROS2Handler::operator()(carla::ros2::VehicleControl &Source)
 {
-  if (!_Actor) return;
+  if (!IsValid(_Actor)) return;
 
   ACarlaWheeledVehicle *Vehicle = Cast<ACarlaWheeledVehicle>(_Actor);
-  if (!Vehicle) return;
+  if (!IsValid(Vehicle)) return;
 
   // setup control values
   FVehicleControl NewControl;
@@ -30,10 +30,10 @@ void ActorROS2Handler::operator()(carla::ros2::VehicleControl &Source)
 
 void ActorROS2Handler::operator()(carla::ros2::VehicleAckermannControl &Source)
 {
-  if (!_Actor) return;
+  if (!IsValid(_Actor)) return;
 
   ACarlaWheeledVehicle *Vehicle = Cast<ACarlaWheeledVehicle>(_Actor);
-  if (!Vehicle) return;
+  if (!IsValid(Vehicle)) return;
 
   // setup control values
   FVehicleAckermannControl NewControl;
@@ -48,10 +48,10 @@ void ActorROS2Handler::operator()(carla::ros2::VehicleAckermannControl &Source)
 
 void ActorROS2Handler::operator()(carla::ros2::MessageControl Message)
 {
-  if (!_Actor) return;
+  if (!IsValid(_Actor)) return;
 
   ACarlaWheeledVehicle *Vehicle = Cast<ACarlaWheeledVehicle>(_Actor);
-  if (!Vehicle) return;
+  if (!IsValid(Vehicle)) return;
 
   Vehicle->PrintROS2Message(Message.message);
 
@@ -61,10 +61,10 @@ void ActorROS2Handler::operator()(carla::ros2::MessageControl Message)
 
 bool ActorROS2Handler::FlattenSteeringCurve(AActor * Actor)
 {
-  if (!Actor) return false;
+  if (!IsValid(Actor)) return false;
 
   ACarlaWheeledVehicle * const Vehicle = Cast<ACarlaWheeledVehicle>(Actor);
-  if (!Vehicle) return false;
+  if (!IsValid(Vehicle)) return false;
 
   auto VehiclePhysicsControl = Vehicle->GetVehiclePhysicsControl();
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.h
@@ -21,6 +21,8 @@ class ActorROS2Handler
         void operator()(carla::ros2::VehicleAckermannControl &Source);
         void operator()(carla::ros2::MessageControl Message);
 
+        static bool FlattenSteeringCurve(AActor * Actor);
+
     private:
         AActor *_Actor {nullptr};
         std::string _RosName;


### PR DESCRIPTION
## Description
Flatten steering curve of Ego vehicle to be constant 1.0.

This curve modifies max steering depending on the speed (the higher the speed, the lower max steering).
This may be desirable for human players, but it should not be applied when Autoware is controlling the vehicle.

## Evidence
Videos were captured on Lincoln MKZ vehicle.
See how the angle of the wheel changes when using the default steering curve and does not change when using a flat curve.

### Default steering curve applied
https://github.com/user-attachments/assets/03b8e99a-d078-4e19-9e33-190cefb21c28

### Flat constant steering curve
https://github.com/user-attachments/assets/caeb31a4-5336-4b8b-aa6b-d1f38504439a
