### PR TITLE
Fix: IMU correct delta time

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
@@ -100,10 +100,8 @@ const carla::geom::Vector3D AInertialMeasurementUnit::ComputeGyroscopeNoise(
   };
 }
 
-carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer()
+carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer(const float CurrentTime)
 {
-  const float CurrentTime = GetWorld()->GetTimeSeconds();
-
   if (!FMath::IsFinite(PrevTime)) {
     PrevTime = CurrentTime;
     return {};
@@ -201,7 +199,7 @@ float AInertialMeasurementUnit::ComputeCompass()
 void AInertialMeasurementUnit::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaTime)
 {
   TRACE_CPUPROFILER_EVENT_SCOPE(AInertialMeasurementUnit::PostPhysTick);
-  AccelerometerValue = ComputeAccelerometer();
+  AccelerometerValue = ComputeAccelerometer(World->GetTimeSeconds());
   GyroscopeValue = ComputeGyroscope();
   CompassValue = ComputeCompass();
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
@@ -114,7 +114,7 @@ carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer()
   // Used to convert from UE4's cm to meters
   constexpr float TO_METERS = 1e-2;
   // Earth's gravitational acceleration is approximately 9.81 m/s^2
-  constexpr float GRAVITY = 9.81f;
+  constexpr float GRAVITY = -9.81f;
 
   // 2nd derivative of the polynomic (quadratic) interpolation
   // using the point in current time and two previous steps:

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
@@ -132,7 +132,7 @@ carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer(const float
   FVector FVectorAccelerometer = TO_METERS * -2.0f * ( A - B - C );
 
   // If data from previous steps is not set - set it and do not return the calculated data
-  const bool MissingPrev =
+  const bool bMissingPrev =
       PrevLocation[0].ContainsNaN() || PrevLocation[1].ContainsNaN() || !FMath::IsFinite(PrevDeltaTime);
 
   // Update the previous locations
@@ -141,7 +141,7 @@ carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer(const float
   PrevDeltaTime = DeltaTime;
   PrevTime = CurrentTime;
 
-  if (MissingPrev) return {};
+  if (bMissingPrev) return {};
 
   // Add gravitational acceleration
   FVectorAccelerometer.Z += GRAVITY;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.cpp
@@ -100,9 +100,17 @@ const carla::geom::Vector3D AInertialMeasurementUnit::ComputeGyroscopeNoise(
   };
 }
 
-carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer(
-    const float DeltaTime)
+carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer()
 {
+  const float CurrentTime = GetWorld()->GetTimeSeconds();
+
+  if (!FMath::IsFinite(PrevTime)) {
+    PrevTime = CurrentTime;
+    return {};
+  }
+
+  const float DeltaTime = CurrentTime - PrevTime;
+
   // Used to convert from UE4's cm to meters
   constexpr float TO_METERS = 1e-2;
   // Earth's gravitational acceleration is approximately 9.81 m/s^2
@@ -125,10 +133,17 @@ carla::geom::Vector3D AInertialMeasurementUnit::ComputeAccelerometer(
   const FVector C = Y0 / ( H1 * (H1AndH2) );
   FVector FVectorAccelerometer = TO_METERS * -2.0f * ( A - B - C );
 
+  // If data from previous steps is not set - set it and do not return the calculated data
+  const bool MissingPrev =
+      PrevLocation[0].ContainsNaN() || PrevLocation[1].ContainsNaN() || !FMath::IsFinite(PrevDeltaTime);
+
   // Update the previous locations
   PrevLocation[0] = PrevLocation[1];
   PrevLocation[1] = CurrentLocation;
   PrevDeltaTime = DeltaTime;
+  PrevTime = CurrentTime;
+
+  if (MissingPrev) return {};
 
   // Add gravitational acceleration
   FVectorAccelerometer.Z += GRAVITY;
@@ -186,7 +201,7 @@ float AInertialMeasurementUnit::ComputeCompass()
 void AInertialMeasurementUnit::PostPhysTick(UWorld *World, ELevelTick TickType, float DeltaTime)
 {
   TRACE_CPUPROFILER_EVENT_SCOPE(AInertialMeasurementUnit::PostPhysTick);
-  AccelerometerValue = ComputeAccelerometer(DeltaTime);
+  AccelerometerValue = ComputeAccelerometer();
   GyroscopeValue = ComputeGyroscope();
   CompassValue = ComputeCompass();
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
@@ -86,7 +86,7 @@ private:
   FVector BiasGyro;
 
   /// Used to compute the acceleration
-  std::array<FVector, 2> PrevLocation{
+  TArray<FVector, TFixedAllocator<2>> PrevLocation{
     FVector::OneVector * std::numeric_limits<float>::quiet_NaN(),
     FVector::OneVector * std::numeric_limits<float>::quiet_NaN()
   };

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
@@ -103,5 +103,4 @@ private:
 
   /// Magnetometer value calculated after each PostPhysTick
   float CompassValue;
-	
 };

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
@@ -43,7 +43,7 @@ public:
       const FVector &Gyroscope);
 
   /// Accelerometer: measures linear acceleration in m/s^2
-  carla::geom::Vector3D ComputeAccelerometer(const float DeltaTime);
+  carla::geom::Vector3D ComputeAccelerometer();
 
   /// Gyroscope: measures angular velocity in rad/sec
   carla::geom::Vector3D ComputeGyroscope();
@@ -86,10 +86,14 @@ private:
   FVector BiasGyro;
 
   /// Used to compute the acceleration
-  std::array<FVector, 2> PrevLocation;
+  std::array<FVector, 2> PrevLocation{
+    FVector::OneVector * std::numeric_limits<float>::quiet_NaN(),
+    FVector::OneVector * std::numeric_limits<float>::quiet_NaN()
+  };
 
   /// Used to compute the acceleration
-  float PrevDeltaTime;
+  float PrevDeltaTime{std::numeric_limits<float>::quiet_NaN()};
+  float PrevTime{std::numeric_limits<float>::quiet_NaN()};
 
   /// Accelerometer value calculated after each PostPhysTick
   carla::geom::Vector3D AccelerometerValue;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Sensor/InertialMeasurementUnit.h
@@ -43,7 +43,7 @@ public:
       const FVector &Gyroscope);
 
   /// Accelerometer: measures linear acceleration in m/s^2
-  carla::geom::Vector3D ComputeAccelerometer();
+  carla::geom::Vector3D ComputeAccelerometer(const float CurrentTime);
 
   /// Gyroscope: measures angular velocity in rad/sec
   carla::geom::Vector3D ComputeGyroscope();


### PR DESCRIPTION
# Description
Fixes the IMU linear acceleration calculation by utilizing a correct delta time.

Originally a delta time provided as an argument in `PostPhysTick` has been used, however this was not correct.

The `PostPhysTick` provides `DeltaTime` of 0.01 always (no matter the sensor rate), because we set the simulation rate to 100Hz (when using `autoware_demo.py` script).
The IMU is called every 3rt or 4th call, because of its configure 30Hz rate, but at the argument still gets 0.01.

Thus, a custom time tracking method was implemented where each call a time is checked, and a delta time is calculated based on the difference between times in two consecutive calls.

> [!IMPORTANT]
> Also, gravity has been changed to negative, because Z axis is pointing up and gravity is pulling down.

# Evidences
## IMU after changes vs manually calculated linear acceleration
<img width="1920" height="1200" alt="after_changes_with_debug_data_in_covariance003_comparison_no_gravity" src="https://github.com/user-attachments/assets/6b9f7c79-5052-4ab8-a814-6f4e0965419f" />

_The plot 'accel' is the manually calculated one. In this test, gravity was disabled so it is easier to manually calculate the acceleration._

## Comparison with different frequencies
> [!NOTE]
> Notice how **Before** for 25Hz the plot looks fine, but the Y-axis values are way higher. The plot shape is fine, because in 25Hz IMU is called exactly every 4 frames so the delta time is always the same (so using constant 0.01 does retain the plot shape). However using delta time of 0.01instead of 0.04 (correct of 25Hz) makes the calculated values have a wrong scale - thus the Y-axis value difference).
>
> **Before** for the 30Hz the plot looks completely incorrect. This is because at 30Hz the IMU is called with different real delta times. This is caused by the fact that 100 (simulation rate) is not divisible by 30 (IMU rate). Therefore every 3rd or 4th reading is scaled by another factor than the other readings. This makes the plot look like like this.
>
> **After** the changes the plots look very similar for both 25Hz and 30Hz and the acceleration is nearly the same as the manually calculated acceleration (see the **Comparison with different frequencies** above).

### Before
#### IMU 25Hz
<img width="1920" height="1200" alt="before_changes_imu_25hz_001" src="https://github.com/user-attachments/assets/ed2ffe35-0bbd-4a11-bb7d-49e9ef8fc4d3" />

#### IMU 30Hz
<img width="1920" height="1200" alt="before_changes_imu_30hz_001" src="https://github.com/user-attachments/assets/dac9ca10-4b31-487f-a8ef-8cc891585f77" />

### After
#### IMU 25Hz
<img width="1920" height="1200" alt="after_changes_with_debug_data_in_covariance_imu_25hz_001" src="https://github.com/user-attachments/assets/e11c95ff-9524-429a-94fb-e4ed5287c845" />

#### IMU 30Hz
<img width="1920" height="1200" alt="after_changes_with_debug_data_in_covariance_imu_30hz_001" src="https://github.com/user-attachments/assets/7ebe0103-a1ff-4e68-8aa2-efb82e58de38" />
