### PR TITLE
General refactor and improvements for autoware_demo.py

### DIFF
--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -303,7 +303,7 @@ def move_spectator(world, ego_vehicle):
     spectator.set_transform(spectator_tf)
 
 
-def apply_world_settings(client, world, map_name="Town10HD_Opt"):
+def apply_world_settings(client, world, map_name=None):
     """
     Stores all settings related to the simulation world.
     Applies Synchronous mode + fixed time-step into world settings.
@@ -313,7 +313,12 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     :param map_name: Map to load and apply settings to.
     """
 
+    if map_name is None:
+    	print('Cannot load provided map')
+    	return
+
     # Load the desired map
+    print(f"Loading map: {map_name}")
     client.load_world(map_name)
 
     # Get Settings
@@ -421,6 +426,9 @@ def main():
     argparser.add_argument(
         '--resync_mode', action='store_true',
         help='Resynchronize to the current time when lag exceeds the acceptable threshold')
+    argparser.add_argument(
+    	'--load_map', nargs='?', const='Town10HD_Opt',
+    	help='Load the provided map')
     args = argparser.parse_args()
 
     # Get Client info
@@ -428,8 +436,11 @@ def main():
     client.set_timeout(60.0)
     world = client.get_world()
 
+    # Determine which map to load
+    map_name = args.load_map if args.load_map is not None else 'Town10HD_Opt'
+
     # Apply Settings
-    apply_world_settings(client, world)
+    apply_world_settings(client, world, map_name)
     log_info("Simulation time scale is %f" % args.time_scale)
 
     # Spawn Ego

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -438,7 +438,7 @@ def run_sync_simulation_loop(world,
 
 
 def parse_hz_rate(value):
-    if value.lower() == "none":
+    if value.lower() in ("none", ''):
         return None
     try:
         return int(value)

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -328,7 +328,6 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no neet of extreme physics realism
     settings.max_substeps = 10
 
-
     world.apply_settings(settings)
 
     # Disable TF publishing in CARLA to avoid conflicts.
@@ -337,7 +336,8 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     # client.reload_world(False)  # reload map keeping the world settings
 
 
-def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, ego=None, follow_ego=False):
+def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, ego=None,
+                        follow_ego=False):
     """
     Runs a real-time simulation loop for a synchronous simulation environment.
 

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -6,15 +6,16 @@ import time
 import PyKDL as kdl
 
 # Sim rate has to be 100 to make /clock tick with 100Hz (it ticks each frame)
-DESIRED_SIM_RATE = 100
+DESIRED_SIM_RATE = 100.0 # Hz
+SIM_DT = 1.0 / DESIRED_SIM_RATE # Simulation delta time
 
-def info(text):
+def log_info(text):
     print("[INFO]: %s" % text)
 
-def warning(text):
+def log_warning(text):
     print("[WARNING]: %s" % text)
 
-def error(text):
+def log_error(text):
     print("[ERROR]: %s" % text)
 
 class ROS2:
@@ -251,7 +252,7 @@ def spawn_ego_with_sensors(world, spawn_point):
     """Spawns a controllable vehicle with a basic sensor configuration
 
     The sensor configuration is compatible with the one for Lexus RX450h in AWSIM.
-    The vehicle itself is replaced by Linkoln MKZ available in CARLA."""
+    The vehicle itself is replaced by Lincoln MKZ available in CARLA."""
 
     blueprint_library = world.get_blueprint_library()
 
@@ -288,6 +289,26 @@ def move_spectator(world, ego_vehicle):
 
     spectator.set_transform(spectator_tf)
 
+def apply_world_settings(client, world, map_name="Town10HD_Opt"):
+    # Load the desired map
+    client.load_world(map_name)
+
+    # Get Settings
+    settings = world.get_settings()
+
+    # Set synchronous mode
+    settings.synchronous_mode = True
+    settings.fixed_delta_seconds = SIM_DT
+
+    # Set physics substepping
+    settings.substepping = True
+    settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no neet of extreme physics realism
+    settings.max_substeps = 10
+
+    world.apply_settings(settings)
+    client.reload_world(False)  # reload map keeping the world settings
+    log_info("Simulation time scale is %f" % args.time_scale)
+
 def main():
     argparser = argparse.ArgumentParser(
         description='CARLA Automatic Control Client')
@@ -308,9 +329,13 @@ def main():
         help='Follow Ego vehicle')
     args = argparser.parse_args()
 
+    # Get Client info
     client = carla.Client(args.host, args.port)
     client.set_timeout(60.0)
     world = client.get_world()
+
+    # Apply Settings
+    apply_world_settings(client, world, "Town10HD_Opt")
 
     # Autoware will be publishing TF information based on the URDF files
     # of the vehicle and sensor kit. Disable TF publishing in CARLA
@@ -321,48 +346,48 @@ def main():
     ego = spawn_ego_with_sensors(world, spawn_point)
     move_spectator(world, ego)
 
-    info('Ego spawned!')
+    log_info('Ego spawned!')
     time.sleep(0.05)  # Without this sometimes spectator would not move
 
-    # Set synchronous mode
-    settings = world.get_settings()
-    settings.synchronous_mode = True
-    settings.fixed_delta_seconds = 1.0 / DESIRED_SIM_RATE
-    world.apply_settings(settings)
+    log_warning('Kill this script before stopping simulation!')
 
-    info("Simulation time scale is %f" % args.time_scale)
-
-    warning('Kill this script before stopping simulation!')
+    # Run simulation loop
+    time_scale = args.time_scale  # 1.0 for real-time, >1 for faster sim
+    real_dt = SIM_DT / time_scale  # how much real time per sim tick
 
     frame_count = 0
-
     start_time = time.time()
-    last_behind_error_time = start_time
-    # Tick world to follow desired time_scale
+    next_tick_time = start_time
+
     try:
         while True:
             current_time = time.time()
-            real_time_passed = current_time - start_time
-            sim_time_passed = real_time_passed * args.time_scale
-            desired_frame_count = math.floor(sim_time_passed * DESIRED_SIM_RATE)
 
-            if desired_frame_count <= frame_count:
-                continue
+            # Wait until it's time for next tick
+            wait_time = next_tick_time - current_time
+            if wait_time > 0:
+                time.sleep(wait_time)
 
-            frame_behind_count = max(desired_frame_count - frame_count, 0)
-            if (frame_behind_count > 10) and \
-                (current_time > last_behind_error_time + 2.0):  # Error every 2 seconds
-                    last_behind_error_time = current_time
-                    error(f'Simulation cannot keep up with the desired time scale!!! ({frame_behind_count} frames behind)')
-
+            # Advance simulation deterministically
             world.tick()
             frame_count += 1
 
+            # Move spectator if needed
             if args.follow:
                 move_spectator(world, ego)
 
+            # Schedule the next tick
+            next_tick_time += real_dt
+
+            # If we are behind, log and catch up
+            lag = time.time() - next_tick_time
+            if lag > 0.02:  # more than 50ms lag
+                log_warning(f"Simulation is {lag*1000:.1f} ms behind schedule")
+                # Option 1: reset next_tick_time = current_time  (resynchronize)
+                next_tick_time = time.time()
+
     except:  # KeyboardInterrupt:
-        info("Exiting, restoring asynchronous mode...")
+        log_info("Exiting, restoring asynchronous mode...")
         # Set asynchronous mode, otherwise simulation will crash
         settings = world.get_settings()
         settings.synchronous_mode = False

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -334,7 +334,7 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     # client.reload_world(False)  # reload map keeping the world settings
 
 
-def run_simulation_loop(target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, world=None, ego=None, follow_ego=False):
+def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, ego=None, follow_ego=False):
     """
     Runs a real-time simulation loop for a synchronous simulation environment.
 
@@ -369,6 +369,10 @@ def run_simulation_loop(target_time_scale=1.0, acceptable_lag=0.05, should_resyn
     real_dt = SIM_DT / target_time_scale
     frame_count = 0
     next_tick_time = time.time()
+
+    if world is None:
+        log_error("World instance is invalid! Cannot proceed with simulation tick.")
+        return
 
     try:
         while True:

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -345,28 +345,17 @@ def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, shoul
     `target_time_scale`, maintaining real-time pacing. It adjusts for timing
     and can optionally resynchronize if the simulation falls behind.
 
-    Parameters
-    ----------
-    world : object
-        The simulation world instance.
-    ego : object, optional
-        The main vehicle actor - player pawn.
-    target_time_scale : float, default=1.0
-        The simulation speed multiplier. Higher values make the simulation run faster, and lower to run slower
-        relative to real time (2.0 = twice real-time speed, 0.5 = half the real-time speed).
-    acceptable_lag : float, default=0.05
-        The maximum acceptable lag. If the loop falls behind by more than
-        this value, a warning is logged.
-    should_resync : bool, default=False
-        If True, the simulation will resynchronize to the current time when lag exceeds
-        the acceptable threshold.
-    follow_ego : bool, default=False
-        If True, moves the spectator camera to follow the ego actor each tick.
-
     Notes
     -----
     - This function runs indefinitely until interrupted (e.g., with Ctrl+C).
     - When interrupted, it restores the world to asynchronous mode to prevent crashes.
+
+    :param world: The simulation world instance.
+    :param ego: The main vehicle actor - player pawn.
+    :param target_time_scale: The simulation speed multiplier. Higher values make the simulation run faster, and lower to run slower relative to real time (2.0 = twice real-time speed, 0.5 = half the real-time speed).
+    :param acceptable_lag: The maximum acceptable lag. If the loop falls behind by more than this value, a warning is logged.
+    :param should_resync: If True, the simulation will resynchronize to the current time when lag exceeds the acceptable threshold.
+    :param follow_ego: If True, moves the spectator camera to follow the ego actor each tick.
     """
 
     real_dt = SIM_DT / target_time_scale

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -5,8 +5,6 @@ import argparse
 import time
 import PyKDL as kdl
 
-from sympy.matrices.densearith import negate
-
 # Sim rate has to be 100 to make /clock tick with 100Hz (it ticks each frame)
 DESIRED_SIM_RATE = 100.0  # Hz
 SIM_DT = 1.0 / DESIRED_SIM_RATE  # Simulation delta time
@@ -313,7 +311,7 @@ class TimeStepData:
         self.hz_rate = hz_rate
 
     def get_sim_dt(self):
-        return 1 / self.hz_rate if self.hz_rate is not None else None
+        return 1 / self.hz_rate if self.hz_rate not in (None, 0) else None
 
 
 def apply_world_settings(client, world, TimeStepData, map_name=None):
@@ -450,7 +448,7 @@ def main():
         help='Run the server and client in asynchronous mode.')
     argparser.add_argument(
         '--hz_rate', nargs=int, const=100,
-        help='Set None for variable time step, otherwise fixed time step will be used with target hz rate.')
+        help='Set None or 0 for variable time step, otherwise fixed time step will be used with target hz rate.')
     args = argparser.parse_args()
 
     # Get Client info
@@ -462,11 +460,15 @@ def main():
     map_name = args.load_map if args.load_map is not None else 'Town10HD_Opt'
 
     # Determine TimeStep Data to be used
-    time_step_info = TimeStepData(synchronous_mode=negate(args.async_run), hz_rate=args.hz_rate)
+    time_step_info = TimeStepData(synchronous_mode=(not args.async_run), hz_rate=args.hz_rate)
 
     # Apply Settings
     apply_world_settings(client=client, world=world, TimeStepData=time_step_info, map_name=map_name)
-    log_info("Simulation time scale: %f, fixed time step: %s, running in synchronous mode: %s" % args.time_scale % time_step_info.hz_rate % time_step_info.synchronous_mode)
+    log_info(
+        f"Simulation time scale: {args.time_scale:.2f}, "
+        f"fixed time step: {time_step_info.hz_rate}, "
+        f"running in synchronous mode: {time_step_info.synchronous_mode}"
+    )
 
     # Spawn Ego
     spawn_point = random.choice(world.get_map().get_spawn_points())

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -385,10 +385,9 @@ def main():
 
             # If we are behind, log and catch up
             lag = time.time() - next_tick_time
-            if lag > 0.02:  # more than 50ms lag
+            if lag > 0.05:  # more than 50ms lag
                 log_warning(f"Simulation is {lag*1000:.1f} ms behind schedule")
-                # Option 1: reset next_tick_time = current_time  (resynchronize)
-                next_tick_time = time.time()
+                next_tick_time = time.time() # resynchronize
 
     except:  # KeyboardInterrupt:
         log_info("Exiting, restoring asynchronous mode...")

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -324,9 +324,9 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     settings.fixed_delta_seconds = SIM_DT
 
     # Set physics substepping
-    settings.substepping = True
-    settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no neet of extreme physics realism
-    settings.max_substeps = 10
+    settings.substepping = False
+    # settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no neet of extreme physics realism
+    # settings.max_substeps = 10
 
     world.apply_settings(settings)
 
@@ -418,6 +418,9 @@ def main():
     argparser.add_argument(
         '--follow', action='store_true',
         help='Follow Ego vehicle')
+    argparser.add_argument(
+        '--resync_mode', action='store_true',
+        help='Resynchronize to the current time when lag exceeds the acceptable threshold')
     args = argparser.parse_args()
 
     # Get Client info
@@ -440,7 +443,7 @@ def main():
     log_warning('Kill this script before stopping simulation!')
 
     # Run simulation loop
-    run_simulation_loop(target_time_scale=args.time_scale, follow_ego=True, world=world, ego=ego)
+    run_simulation_loop(target_time_scale=args.time_scale, follow_ego=True, world=world, ego=ego, should_resync=args.resync_mode)
 
 
 if __name__ == '__main__':

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -315,7 +315,11 @@ class TimeStepData:
         return self.synchronous_mode and self.hz_rate not in (None, 0) and not self.phys_substepping
 
 
-def apply_world_settings(client, world, time_step_info, map_name=None):
+def get_current_map_name(world):
+    return world.get_map().name.split('/')[-1]
+
+
+def apply_world_settings(client, world, time_step_info, map_name=None, force_map_reload=False):
     """
 	Stores all settings related to the simulation world.
 	Applies Synchronous mode + fixed time-step into world settings.
@@ -324,6 +328,7 @@ def apply_world_settings(client, world, time_step_info, map_name=None):
 	:param world: The simulation world instance.
 	:param time_step_info: Instance of TimeStepData.
 	:param map_name: Map to load and apply settings to.
+	:param force_map_reload: Forces map to be reloaded. Reload action cleans up the scene.
 	"""
 
     if map_name is None:
@@ -331,8 +336,11 @@ def apply_world_settings(client, world, time_step_info, map_name=None):
         return
 
     # Load the desired map
-    print(f"Loading map: {map_name}")
-    client.load_world(map_name)
+    if force_map_reload or (get_current_map_name(world) != map_name):
+        print(f"Loading map: {map_name}")
+        client.load_world(map_name)
+
+    print(f'Loaded map: {get_current_map_name(world)}')
 
     # Get Settings
     settings = world.get_settings()
@@ -477,6 +485,9 @@ def main():
         help="Load a map the provided map."
     )
     argparser.add_argument(
+        '--force_reload', action='store_true',
+        help='Force map reload.')
+    argparser.add_argument(
         '--substepping', action='store_true',
         help='Enable substepping for physics.')
     argparser.add_argument(
@@ -504,7 +515,8 @@ def main():
     apply_world_settings(client=client,
                          world=world,
                          time_step_info=time_step_info,
-                         map_name=args.load_map)
+                         map_name=args.load_map,
+                         force_map_reload=args.force_reload)
     log_info(
         f"Applied settings:\n"
         f"\tsynchronous mode: {time_step_info.synchronous_mode}\n"

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -418,6 +418,13 @@ def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, shoul
         settings.fixed_delta_seconds = None
         world.apply_settings(settings)
 
+def parse_hz_rate(value):
+    if value.lower() == "none":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("hz_rate must be an integer or 'None'.")
 
 def main():
     argparser = argparse.ArgumentParser(
@@ -441,14 +448,21 @@ def main():
         '--resync_mode', action='store_true',
         help='Resynchronize to the current time when lag exceeds the acceptable threshold')
     argparser.add_argument(
-        '--load_map', nargs='?', const='Town10HD_Opt',
-        help='Load the provided map')
+        '--load_map',
+        nargs='?',
+        const='Town10HD_Opt',  # used when flag present but no value
+        default='Town10HD_Opt',  # used when flag absent
+        help="Load a map the provided map."
+    )
     argparser.add_argument(
         '--async_run', action='store_true',
         help='Run the server and client in asynchronous mode.')
     argparser.add_argument(
-        '--hz_rate', nargs=int, const=100,
-        help='Set None or 0 for variable time step, otherwise fixed time step will be used with target hz rate.')
+        '--hz_rate',
+        type=parse_hz_rate,
+        default=100,
+        help="Set 'None' or 0 for variable time step, otherwise use an integer for fixed time step rate."
+    )
     args = argparser.parse_args()
 
     # Get Client info
@@ -456,14 +470,11 @@ def main():
     client.set_timeout(60.0)
     world = client.get_world()
 
-    # Determine which map to load
-    map_name = args.load_map if args.load_map is not None else 'Town10HD_Opt'
-
     # Determine TimeStep Data to be used
     time_step_info = TimeStepData(synchronous_mode=(not args.async_run), hz_rate=args.hz_rate)
 
     # Apply Settings
-    apply_world_settings(client=client, world=world, TimeStepData=time_step_info, map_name=map_name)
+    apply_world_settings(client=client, world=world, TimeStepData=time_step_info, map_name=args.load_map)
     log_info(
         f"Simulation time scale: {args.time_scale:.2f}, "
         f"fixed time step: {time_step_info.hz_rate}, "

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -315,8 +315,7 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     world.set_publish_tf(False) # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
 
     world.apply_settings(settings)
-    client.reload_world(False)  # reload map keeping the world settings
-    log_info("Simulation time scale is %f" % args.time_scale)
+    # client.reload_world(False)  # reload map keeping the world settings
 
 def main():
     argparser = argparse.ArgumentParser(
@@ -344,14 +343,16 @@ def main():
     world = client.get_world()
 
     # Apply Settings
-    apply_world_settings(client, world, "Town10HD_Opt")
+    apply_world_settings(client, world)
+
+    log_info("Simulation time scale is %f" % args.time_scale)
 
     spawn_point = random.choice(world.get_map().get_spawn_points())
     ego = spawn_ego_with_sensors(world, spawn_point)
-    move_spectator(world, ego)
 
+    world.tick()
+    move_spectator(world, ego)
     log_info('Ego spawned!')
-    time.sleep(0.05)  # Without this sometimes spectator would not move
 
     log_warning('Kill this script before stopping simulation!')
 

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -499,9 +499,12 @@ def main():
                          time_step_info=time_step_info,
                          map_name=args.load_map)
     log_info(
-        f"Simulation time scale: {args.time_scale:.2f}, "
-        f"fixed time step: {time_step_info.hz_rate}, "
-        f"running in synchronous mode: {time_step_info.synchronous_mode}"
+        f"Applied settings:\n"
+        f"\tsynchronous mode: {time_step_info.synchronous_mode}\n"
+        f"\tfixed time step: {time_step_info.hz_rate} (in Hz)\n"
+        f"\tphysics substepping: {time_step_info.phys_substepping}\n"
+        f"\ttime scale: {args.time_scale:.2f}\n"
+        f"\tpure step execution: {time_step_info.is_pure_step_execution_enabled()}"
     )
 
     # Spawn Ego

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -373,22 +373,22 @@ def main():
             if wait_time > 0:
                 time.sleep(wait_time)
 
-            # Advance simulation deterministically
+            # Advance simulation
             world.tick()
             frame_count += 1
 
-            # Move spectator if needed
+            # Move spectator
             if args.follow:
                 move_spectator(world, ego)
 
             # Schedule the next tick
             next_tick_time += real_dt
 
-            # If we are behind, log and catch up
+            # If behind, log and catch up
             lag = time.time() - next_tick_time
             if lag > 0.05:  # more than 50ms lag
                 log_warning(f"Simulation is {lag*1000:.1f} ms behind schedule")
-                next_tick_time = time.time() # resynchronize
+                # next_tick_time = time.time() # resynchronize - disabled since we want to catch up as fast as possible with loss
 
     except:  # KeyboardInterrupt:
         log_info("Exiting, restoring asynchronous mode...")

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -306,21 +306,26 @@ def move_spectator(world, ego_vehicle):
 
 
 class TimeStepData:
-    def __init__(self, synchronous_mode=True, hz_rate=100):
+    def __init__(self, synchronous_mode=True, hz_rate=100, phys_substepping=False):
         self.synchronous_mode = synchronous_mode
         self.hz_rate = hz_rate
+        self.phys_substepping = phys_substepping
 
     def get_sim_dt(self):
         return 1 / self.hz_rate if self.hz_rate not in (None, 0) else None
 
+    def is_pure_step_execution_enabled(self):
+        return self.synchronous_mode and self.hz_rate not in (None, 0) and not self.phys_substepping
 
-def apply_world_settings(client, world, TimeStepData, map_name=None):
+
+def apply_world_settings(client, world, time_step_info, map_name=None):
     """
 	Stores all settings related to the simulation world.
 	Applies Synchronous mode + fixed time-step into world settings.
 
 	:param client: Connected client to the Carla server instance.
 	:param world: The simulation world instance.
+	:param time_step_info: Instance of TimeStepData.
 	:param map_name: Map to load and apply settings to.
 	"""
 
@@ -336,22 +341,26 @@ def apply_world_settings(client, world, TimeStepData, map_name=None):
     settings = world.get_settings()
 
     # Set synchronous mode
-    settings.synchronous_mode = TimeStepData.synchronous_mode
-    settings.fixed_delta_seconds = SIM_DT
+    settings.synchronous_mode = time_step_info.synchronous_mode
+    settings.fixed_delta_seconds = time_step_info.get_sim_dt()
 
     # Set physics substepping
-    settings.substepping = False
-    # settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no neet of extreme physics realism
-    # settings.max_substeps = 10
+    if time_step_info.is_pure_step_execution_enabled():
+        settings.substepping = False
+    elif time_step_info.synchronous_mode:
+        settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no need of extreme physics realism
+        settings.max_substeps = 10
+        settings.substepping = settings.fixed_delta_seconds <= settings.max_substep_delta_time * settings.max_substeps # carla condition
+    else:
+        settings.substepping = time_step_info.phys_substepping
 
+    # Apply settings
     world.apply_settings(settings)
+    # client.reload_world(False)  # reload map keeping the world settings
 
     # Disable TF publishing in CARLA to avoid conflicts.
     world.set_publish_tf(
         False)  # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
-
-
-# client.reload_world(False)  # reload map keeping the world settings
 
 
 def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, ego=None,
@@ -455,6 +464,9 @@ def main():
         help="Load a map the provided map."
     )
     argparser.add_argument(
+        '--phys_substepping', action='store_true',
+        help='Enable substepping for physics.')
+    argparser.add_argument(
         '--async_run', action='store_true',
         help='Run the server and client in asynchronous mode.')
     argparser.add_argument(
@@ -471,10 +483,15 @@ def main():
     world = client.get_world()
 
     # Determine TimeStep Data to be used
-    time_step_info = TimeStepData(synchronous_mode=(not args.async_run), hz_rate=args.hz_rate)
+    time_step_info = TimeStepData(synchronous_mode=(not args.async_run),
+                                  hz_rate=args.hz_rate,
+                                  phys_substepping=args.phys_substepping)
 
     # Apply Settings
-    apply_world_settings(client=client, world=world, TimeStepData=time_step_info, map_name=args.load_map)
+    apply_world_settings(client=client,
+                         world=world,
+                         time_step_info=time_step_info,
+                         map_name=args.load_map)
     log_info(
         f"Simulation time scale: {args.time_scale:.2f}, "
         f"fixed time step: {time_step_info.hz_rate}, "

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -363,8 +363,13 @@ def apply_world_settings(client, world, time_step_info, map_name=None):
         False)  # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
 
 
-def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, ego=None,
-                        follow_ego=False, target_sim_dt=0.01):
+def run_simulation_loop(world,
+                        target_time_scale=1.0,
+                        acceptable_lag=0.05,
+                        should_resync=False,
+                        ego=None,
+                        follow_ego=False,
+                        target_sim_dt=0.01):
     """
 	Runs a real-time simulation loop for a synchronous simulation environment.
 
@@ -380,9 +385,10 @@ def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, shoul
 	:param world: The simulation world instance.
 	:param ego: The main vehicle actor - player pawn.
 	:param target_time_scale: The simulation speed multiplier. Higher values make the simulation run faster, and lower to run slower relative to real time (2.0 = twice real-time speed, 0.5 = half the real-time speed).
-	:param acceptable_lag: The maximum acceptable lag. If the loop falls behind by more than this value, a warning is logged.
-	:param should_resync: If True, the simulation will resynchronize to the current time when lag exceeds the acceptable threshold.
+	:param acceptable_lag: The maximum acceptable delay in seconds between real time and simulation time. If the loop falls behind by more than this value, a warning is logged.
+	:param should_resync: If True, when lag exceeds the acceptable threshold, the loop resets its internal schedule to the current wall time, causing the next tick to run immediately to catch up to real time.
 	:param follow_ego: If True, moves the spectator camera to follow the ego actor each tick.
+	:param target_sim_dt: Fixed simulation step (in seconds). Used together with `target_time_scale` to determine real-time pacing between ticks.
 	"""
 
     real_dt = target_sim_dt / target_time_scale

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -1,13 +1,10 @@
-import carla
+import argparse
 import math
 import random
-import argparse
 import time
-import PyKDL as kdl
 
-# Sim rate has to be 100 to make /clock tick with 100Hz (it ticks each frame)
-DESIRED_SIM_RATE = 100.0  # Hz
-SIM_DT = 1.0 / DESIRED_SIM_RATE  # Simulation delta time
+import PyKDL as kdl
+import carla
 
 
 def log_info(text):
@@ -350,7 +347,7 @@ def apply_world_settings(client, world, time_step_info, map_name=None):
     elif time_step_info.synchronous_mode:
         settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no need of extreme physics realism
         settings.max_substeps = 10
-        settings.substepping = settings.fixed_delta_seconds <= settings.max_substep_delta_time * settings.max_substeps # carla condition
+        settings.substepping = settings.fixed_delta_seconds <= settings.max_substep_delta_time * settings.max_substeps  # carla condition
     else:
         settings.substepping = time_step_info.phys_substepping
 
@@ -433,6 +430,7 @@ def run_simulation_loop(world,
         settings.fixed_delta_seconds = None
         world.apply_settings(settings)
 
+
 def parse_hz_rate(value):
     if value.lower() == "none":
         return None
@@ -440,6 +438,7 @@ def parse_hz_rate(value):
         return int(value)
     except ValueError:
         raise argparse.ArgumentTypeError("hz_rate must be an integer or 'None'.")
+
 
 def main():
     argparser = argparse.ArgumentParser(

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -305,7 +305,7 @@ def move_spectator(world, ego_vehicle):
 class TimeStepData:
     def __init__(self, synchronous_mode=True, hz_rate=100, phys_substepping=False):
         self.synchronous_mode = synchronous_mode
-        self.hz_rate = hz_rate
+        self.hz_rate = hz_rate if hz_rate not in (None, 0) else None
         self.phys_substepping = phys_substepping
 
     def get_sim_dt(self):
@@ -465,8 +465,10 @@ def main():
         '--follow', action='store_true',
         help='Follow Ego vehicle')
     argparser.add_argument(
-        '--resync_mode', action='store_true',
-        help='Resynchronize to the current time when lag exceeds the acceptable threshold')
+        '--resync', action='store_true',
+        help='Resynchronize to the current time when lag exceeds the acceptable threshold. '
+             'Only available for synchronized mode.'
+    )
     argparser.add_argument(
         '--load_map',
         nargs='?',
@@ -475,10 +477,10 @@ def main():
         help="Load a map the provided map."
     )
     argparser.add_argument(
-        '--phys_substepping', action='store_true',
+        '--substepping', action='store_true',
         help='Enable substepping for physics.')
     argparser.add_argument(
-        '--async_run', action='store_true',
+        '--run_async', action='store_true',
         help='Run the server and client in asynchronous mode.')
     argparser.add_argument(
         '--hz_rate',
@@ -494,9 +496,9 @@ def main():
     world = client.get_world()
 
     # Determine TimeStep Data to be used
-    time_step_info = TimeStepData(synchronous_mode=(not args.async_run),
+    time_step_info = TimeStepData(synchronous_mode=(not args.run_async),
                                   hz_rate=args.hz_rate,
-                                  phys_substepping=args.phys_substepping)
+                                  phys_substepping=args.substepping)
 
     # Apply Settings
     apply_world_settings(client=client,
@@ -507,6 +509,7 @@ def main():
         f"Applied settings:\n"
         f"\tsynchronous mode: {time_step_info.synchronous_mode}\n"
         f"\tfixed time step: {time_step_info.hz_rate} (in Hz)\n"
+        f"\tsimulation dt: {time_step_info.get_sim_dt()} (in seconds)\n"
         f"\tphysics substepping: {time_step_info.phys_substepping}\n"
         f"\ttime scale: {args.time_scale:.2f}\n"
         f"\tpure step execution: {time_step_info.is_pure_step_execution_enabled()}"
@@ -525,7 +528,7 @@ def main():
     # Run simulation loop
     time_step_info.synchronous_mode and run_sync_simulation_loop(target_sim_dt=time_step_info.get_sim_dt(),
                                                                  target_time_scale=args.time_scale,
-                                                                 should_resync=args.resync_mode,
+                                                                 should_resync=args.resync,
                                                                  follow_ego=args.follow,
                                                                  world=world,
                                                                  ego=ego)

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -290,6 +290,12 @@ def move_spectator(world, ego_vehicle):
     spectator.set_transform(spectator_tf)
 
 def apply_world_settings(client, world, map_name="Town10HD_Opt"):
+    """
+    Applies Synchronous mode + fixed time-step into world settings.
+
+    Store here all settings related to simulation world.
+    """
+
     # Load the desired map
     client.load_world(map_name)
 
@@ -304,6 +310,9 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     settings.substepping = True
     settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no neet of extreme physics realism
     settings.max_substeps = 10
+
+    # Disable TF publishing in CARLA to avoid conflicts.
+    world.set_publish_tf(False) # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
 
     world.apply_settings(settings)
     client.reload_world(False)  # reload map keeping the world settings
@@ -336,11 +345,6 @@ def main():
 
     # Apply Settings
     apply_world_settings(client, world, "Town10HD_Opt")
-
-    # Autoware will be publishing TF information based on the URDF files
-    # of the vehicle and sensor kit. Disable TF publishing in CARLA
-    # to avoid conflicts.
-    world.set_publish_tf(False)
 
     spawn_point = random.choice(world.get_map().get_spawn_points())
     ego = spawn_ego_with_sensors(world, spawn_point)

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -6,17 +6,21 @@ import time
 import PyKDL as kdl
 
 # Sim rate has to be 100 to make /clock tick with 100Hz (it ticks each frame)
-DESIRED_SIM_RATE = 100.0 # Hz
-SIM_DT = 1.0 / DESIRED_SIM_RATE # Simulation delta time
+DESIRED_SIM_RATE = 100.0  # Hz
+SIM_DT = 1.0 / DESIRED_SIM_RATE  # Simulation delta time
+
 
 def log_info(text):
     print("[INFO]: %s" % text)
 
+
 def log_warning(text):
     print("[WARNING]: %s" % text)
 
+
 def log_error(text):
     print("[ERROR]: %s" % text)
+
 
 class ROS2:
     """
@@ -27,17 +31,18 @@ class ROS2:
     - CARLA uses degrees
     https://github.com/carla-simulator/ros-bridge/blob/e9063d97ff5a724f76adbb1b852dc71da1dcfeec/carla_common/src/carla_common/transforms.py#L307-L310
     """
-    def Location(x : float = 0.0, y : float = 0.0, z : float = 0.0):
-        """In meters"""
-        return carla.Location(x =  x,
-                              y = -y,
-                              z =  z)
 
-    def Rotation(roll : float = 0.0, pitch : float = 0.0, yaw : float = 0.0):
+    def Location(x: float = 0.0, y: float = 0.0, z: float = 0.0):
+        """In meters"""
+        return carla.Location(x=x,
+                              y=-y,
+                              z=z)
+
+    def Rotation(roll: float = 0.0, pitch: float = 0.0, yaw: float = 0.0):
         """In radians"""
-        return carla.Rotation(roll  =  math.degrees(roll),
-                              pitch = -math.degrees(pitch),
-                              yaw   = -math.degrees(yaw))
+        return carla.Rotation(roll=math.degrees(roll),
+                              pitch=-math.degrees(pitch),
+                              yaw=-math.degrees(yaw))
 
     class Transform:
         """
@@ -51,12 +56,12 @@ class ROS2:
         yaw = 0.0
 
         def __init__(self,
-                     x : float = 0.0,
-                     y : float = 0.0,
-                     z : float = 0.0,
-                     roll : float = 0.0,
-                     pitch : float = 0.0,
-                     yaw : float = 0.0):
+                     x: float = 0.0,
+                     y: float = 0.0,
+                     z: float = 0.0,
+                     roll: float = 0.0,
+                     pitch: float = 0.0,
+                     yaw: float = 0.0):
             self.x = x
             self.y = y
             self.z = z
@@ -83,6 +88,7 @@ class ROS2:
 
             return ROS2.Transform(x, y, z, roll, pitch, yaw)
 
+
 def chain_transforms(transforms):
     """
     :param transforms: list of ROS2.Transform
@@ -92,6 +98,7 @@ def chain_transforms(transforms):
     for t in transforms[1:]:
         F = F * t.to_kdl()
     return ROS2.Transform.from_kdl(F)
+
 
 def generate_vlp16_blueprint(blueprint_library):
     """Generates a blueprint for VLP16
@@ -119,6 +126,7 @@ def generate_vlp16_blueprint(blueprint_library):
 
     return blueprint
 
+
 def generate_traffic_light_camera_blueprint(blueprint_library):
     """Generates a traffic light camera
 
@@ -140,6 +148,7 @@ def generate_traffic_light_camera_blueprint(blueprint_library):
 
     return blueprint
 
+
 def generate_imu_blueprint(blueprint_library):
     """Generates a blueprint for IMU"""
 
@@ -153,6 +162,7 @@ def generate_imu_blueprint(blueprint_library):
 
     return blueprint
 
+
 def generate_gnss_blueprint(blueprint_library):
     """Generates a blueprint for GNSS"""
 
@@ -165,6 +175,7 @@ def generate_gnss_blueprint(blueprint_library):
     blueprint.set_attribute("ros_topic_name", "/sensing/gnss")
 
     return blueprint
+
 
 def spawn_sensors(world, base_link, ego):
     """Spawns sensors relatively to the provided base_link actor
@@ -248,6 +259,7 @@ def spawn_sensors(world, base_link, ego):
     # # NOTE: Enable for ros is not needed, because this sensor uses a global publisher
     # vehicle_status_sensor.enable_for_ros()
 
+
 def spawn_ego_with_sensors(world, spawn_point):
     """Spawns a controllable vehicle with a basic sensor configuration
 
@@ -277,6 +289,7 @@ def spawn_ego_with_sensors(world, spawn_point):
 
     return ego
 
+
 def move_spectator(world, ego_vehicle):
     spectator = world.get_spectator()
 
@@ -288,6 +301,7 @@ def move_spectator(world, ego_vehicle):
     spectator_tf = carla.Transform(spectator_with_offset_position, spectator_tf.rotation)
 
     spectator.set_transform(spectator_tf)
+
 
 def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     """
@@ -311,11 +325,84 @@ def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     settings.max_substep_delta_time = 0.001  # max 1 ms per physics substep, swap to 0.01 if no neet of extreme physics realism
     settings.max_substeps = 10
 
-    # Disable TF publishing in CARLA to avoid conflicts.
-    world.set_publish_tf(False) # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
 
     world.apply_settings(settings)
+
+    # Disable TF publishing in CARLA to avoid conflicts.
+    world.set_publish_tf(
+        False)  # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
     # client.reload_world(False)  # reload map keeping the world settings
+
+
+def run_simulation_loop(target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, world=None, ego=None, follow_ego=False):
+    """
+    Runs a real-time simulation loop for a synchronous simulation environment.
+
+    The loop advances the simulation world in fixed time steps determined by
+    `target_time_scale`, maintaining real-time pacing. It adjusts for timing
+    and can optionally resynchronize if the simulation falls behind.
+
+    Parameters
+    ----------
+    world : object
+        The simulation world instance.
+    ego : object, optional
+        The main vehicle actor - player pawn.
+    target_time_scale : float, default=1.0
+        The simulation speed multiplier. Higher values make the simulation run faster, and lower to run slower
+        relative to real time (2.0 = twice real-time speed, 0.5 = half the real-time speed).
+    acceptable_lag : float, default=0.05
+        The maximum acceptable lag. If the loop falls behind by more than
+        this value, a warning is logged.
+    should_resync : bool, default=False
+        If True, the simulation will resynchronize to the current time when lag exceeds
+        the acceptable threshold.
+    follow_ego : bool, default=False
+        If True, moves the spectator camera to follow the ego actor each tick.
+
+    Notes
+    -----
+    - This function runs indefinitely until interrupted (e.g., with Ctrl+C).
+    - When interrupted, it restores the world to asynchronous mode to prevent crashes.
+    """
+
+    real_dt = SIM_DT / target_time_scale
+    frame_count = 0
+    next_tick_time = time.time()
+
+    try:
+        while True:
+            current_time = time.time()
+
+            # Sleep until it's time for the next tick
+            wait_time = next_tick_time - current_time
+            if wait_time > 0:
+                time.sleep(wait_time)
+
+            # Advance simulation
+            world.tick()
+            frame_count += 1
+
+            # Optional spectator movement
+            if follow_ego and ego is not None:
+                move_spectator(world, ego)
+
+            # Schedule next tick
+            next_tick_time += real_dt
+
+            # Detect and handle lag
+            lag = time.time() - next_tick_time
+            if lag > acceptable_lag:
+                log_warning(f"Simulation is {lag * 1000:.1f} ms behind schedule")
+                if should_resync:
+                    next_tick_time = time.time()
+
+    except KeyboardInterrupt:
+        log_info("Exiting simulation loop, restoring asynchronous mode...")
+        settings = world.get_settings()
+        settings.synchronous_mode = False
+        world.apply_settings(settings)
+
 
 def main():
     argparser = argparse.ArgumentParser(
@@ -344,58 +431,21 @@ def main():
 
     # Apply Settings
     apply_world_settings(client, world)
-
     log_info("Simulation time scale is %f" % args.time_scale)
 
+    # Spawn Ego
     spawn_point = random.choice(world.get_map().get_spawn_points())
     ego = spawn_ego_with_sensors(world, spawn_point)
 
-    world.tick()
+    world.tick()  # tick to process the changes (settings, ego + sensors spawn)
     move_spectator(world, ego)
-    log_info('Ego spawned!')
 
+    log_info('Ego spawned!')
     log_warning('Kill this script before stopping simulation!')
 
     # Run simulation loop
-    time_scale = args.time_scale  # 1.0 for real-time, >1 for faster sim
-    real_dt = SIM_DT / time_scale  # how much real time per sim tick
+    run_simulation_loop(target_time_scale=args.time_scale, follow_ego=True, world=world, ego=ego)
 
-    frame_count = 0
-    start_time = time.time()
-    next_tick_time = start_time
-
-    try:
-        while True:
-            current_time = time.time()
-
-            # Wait until it's time for next tick
-            wait_time = next_tick_time - current_time
-            if wait_time > 0:
-                time.sleep(wait_time)
-
-            # Advance simulation
-            world.tick()
-            frame_count += 1
-
-            # Move spectator
-            if args.follow:
-                move_spectator(world, ego)
-
-            # Schedule the next tick
-            next_tick_time += real_dt
-
-            # If behind, log and catch up
-            lag = time.time() - next_tick_time
-            if lag > 0.05:  # more than 50ms lag
-                log_warning(f"Simulation is {lag*1000:.1f} ms behind schedule")
-                # next_tick_time = time.time() # resynchronize - disabled since we want to catch up as fast as possible with loss
-
-    except:  # KeyboardInterrupt:
-        log_info("Exiting, restoring asynchronous mode...")
-        # Set asynchronous mode, otherwise simulation will crash
-        settings = world.get_settings()
-        settings.synchronous_mode = False
-        world.apply_settings(settings)
 
 if __name__ == '__main__':
     main()

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -331,16 +331,23 @@ def apply_world_settings(client, world, time_step_info, map_name=None, force_map
 	:param force_map_reload: Forces map to be reloaded. Reload action cleans up the scene.
 	"""
 
-    if map_name is None:
-        print('Cannot load provided map')
-        return
-
     # Load the desired map
-    if force_map_reload or (get_current_map_name(world) != map_name):
-        print(f"Loading map: {map_name}")
-        client.load_world(map_name)
+    current_map = get_current_map_name(world)
+    should_reload = map_name and (force_map_reload or current_map.lower() != map_name.lower())
 
-    print(f'Loaded map: {get_current_map_name(world)}')
+    if should_reload:
+        print(f"Loading map: {map_name}")
+        try:
+            client.load_world(map_name)
+            current_map = get_current_map_name(world) # set new world name to active one (current)
+        except Exception as exc:
+            traceback.print_exc()
+            print(
+                f"Provided invalid map name: {map_name}. "
+                f"Please check the spelling and make sure the map is available."
+            )
+
+    print(f'Loaded map: {current_map}')
 
     # Get Settings
     settings = world.get_settings()
@@ -481,7 +488,6 @@ def main():
         '--load_map',
         nargs='?',
         const='Town10HD_Opt',  # used when flag present but no value
-        default='Town10HD_Opt',  # used when flag absent
         help="Load a map the provided map."
     )
     argparser.add_argument(

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -5,6 +5,8 @@ import argparse
 import time
 import PyKDL as kdl
 
+from sympy.matrices.densearith import negate
+
 # Sim rate has to be 100 to make /clock tick with 100Hz (it ticks each frame)
 DESIRED_SIM_RATE = 100.0  # Hz
 SIM_DT = 1.0 / DESIRED_SIM_RATE  # Simulation delta time
@@ -24,13 +26,13 @@ def log_error(text):
 
 class ROS2:
     """
-    ROS2 coordinate system to CARLA coordinate system conversions
-    ROS2 uses right-handed system and CARLA uses left-handed system.
-    Also converts rotation units
-    - ROS2 uses radians
-    - CARLA uses degrees
-    https://github.com/carla-simulator/ros-bridge/blob/e9063d97ff5a724f76adbb1b852dc71da1dcfeec/carla_common/src/carla_common/transforms.py#L307-L310
-    """
+	ROS2 coordinate system to CARLA coordinate system conversions
+	ROS2 uses right-handed system and CARLA uses left-handed system.
+	Also converts rotation units
+	- ROS2 uses radians
+	- CARLA uses degrees
+	https://github.com/carla-simulator/ros-bridge/blob/e9063d97ff5a724f76adbb1b852dc71da1dcfeec/carla_common/src/carla_common/transforms.py#L307-L310
+	"""
 
     def Location(x: float = 0.0, y: float = 0.0, z: float = 0.0):
         """In meters"""
@@ -46,8 +48,8 @@ class ROS2:
 
     class Transform:
         """
-        Transform in ROS2 coordinate system
-        """
+		Transform in ROS2 coordinate system
+		"""
         x = 0.0
         y = 0.0
         z = 0.0
@@ -91,9 +93,9 @@ class ROS2:
 
 def chain_transforms(transforms):
     """
-    :param transforms: list of ROS2.Transform
-    :return: ROS2.Transform
-    """
+	:param transforms: list of ROS2.Transform
+	:return: ROS2.Transform
+	"""
     F = transforms[0].to_kdl()
     for t in transforms[1:]:
         F = F * t.to_kdl()
@@ -103,9 +105,9 @@ def chain_transforms(transforms):
 def generate_vlp16_blueprint(blueprint_library):
     """Generates a blueprint for VLP16
 
-    The following assumptions were made based on the configuration in AWSIM:
-    - 10 Hz publish frequency
-    - 0.2 deg horizontal resolution"""
+	The following assumptions were made based on the configuration in AWSIM:
+	- 10 Hz publish frequency
+	- 0.2 deg horizontal resolution"""
 
     blueprint = blueprint_library.find("sensor.lidar.ray_cast")
 
@@ -130,10 +132,10 @@ def generate_vlp16_blueprint(blueprint_library):
 def generate_traffic_light_camera_blueprint(blueprint_library):
     """Generates a traffic light camera
 
-    The following assumptions were made based on the configuration in AWSIM:
-    - 10 Hz publish frequency
-    - 1920 x 1080 image resolution
-    - 90 deg horizontal field of view"""
+	The following assumptions were made based on the configuration in AWSIM:
+	- 10 Hz publish frequency
+	- 1920 x 1080 image resolution
+	- 90 deg horizontal field of view"""
 
     blueprint = blueprint_library.find("sensor.camera.rgb")
 
@@ -180,9 +182,9 @@ def generate_gnss_blueprint(blueprint_library):
 def spawn_sensors(world, base_link, ego):
     """Spawns sensors relatively to the provided base_link actor
 
-    Positioning of the sensors is taken from the URDF for awsim_sensor_kit_description package at:
-    https://github.com/autowarefoundation/autoware_launch/tree/0.45.3/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description
-    """
+	Positioning of the sensors is taken from the URDF for awsim_sensor_kit_description package at:
+	https://github.com/autowarefoundation/autoware_launch/tree/0.45.3/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description
+	"""
 
     blueprint_library = world.get_blueprint_library()
 
@@ -256,15 +258,17 @@ def spawn_sensors(world, base_link, ego):
         vehicle_status_blueprint,
         carla.Transform(),
         attach_to=base_link)  # Attach to base_link with no offset, because velocities should come from rear axle
-    # # NOTE: Enable for ros is not needed, because this sensor uses a global publisher
-    # vehicle_status_sensor.enable_for_ros()
+
+
+# # NOTE: Enable for ros is not needed, because this sensor uses a global publisher
+# vehicle_status_sensor.enable_for_ros()
 
 
 def spawn_ego_with_sensors(world, spawn_point):
     """Spawns a controllable vehicle with a basic sensor configuration
 
-    The sensor configuration is compatible with the one for Lexus RX450h in AWSIM.
-    The vehicle itself is replaced by Lincoln MKZ available in CARLA."""
+	The sensor configuration is compatible with the one for Lexus RX450h in AWSIM.
+	The vehicle itself is replaced by Lincoln MKZ available in CARLA."""
 
     blueprint_library = world.get_blueprint_library()
 
@@ -303,19 +307,28 @@ def move_spectator(world, ego_vehicle):
     spectator.set_transform(spectator_tf)
 
 
-def apply_world_settings(client, world, map_name=None):
-    """
-    Stores all settings related to the simulation world.
-    Applies Synchronous mode + fixed time-step into world settings.
+class TimeStepData:
+    def __init__(self, synchronous_mode=True, hz_rate=100):
+        self.synchronous_mode = synchronous_mode
+        self.hz_rate = hz_rate
 
-    :param client: Connected client to the Carla server instance.
-    :param world: The simulation world instance.
-    :param map_name: Map to load and apply settings to.
+    def get_sim_dt(self):
+        return 1 / self.hz_rate if self.hz_rate is not None else None
+
+
+def apply_world_settings(client, world, TimeStepData, map_name=None):
     """
+	Stores all settings related to the simulation world.
+	Applies Synchronous mode + fixed time-step into world settings.
+
+	:param client: Connected client to the Carla server instance.
+	:param world: The simulation world instance.
+	:param map_name: Map to load and apply settings to.
+	"""
 
     if map_name is None:
-    	print('Cannot load provided map')
-    	return
+        print('Cannot load provided map')
+        return
 
     # Load the desired map
     print(f"Loading map: {map_name}")
@@ -325,7 +338,7 @@ def apply_world_settings(client, world, map_name=None):
     settings = world.get_settings()
 
     # Set synchronous mode
-    settings.synchronous_mode = True
+    settings.synchronous_mode = TimeStepData.synchronous_mode
     settings.fixed_delta_seconds = SIM_DT
 
     # Set physics substepping
@@ -338,32 +351,34 @@ def apply_world_settings(client, world, map_name=None):
     # Disable TF publishing in CARLA to avoid conflicts.
     world.set_publish_tf(
         False)  # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
-    # client.reload_world(False)  # reload map keeping the world settings
+
+
+# client.reload_world(False)  # reload map keeping the world settings
 
 
 def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, should_resync=False, ego=None,
-                        follow_ego=False):
+                        follow_ego=False, target_sim_dt=0.01):
     """
-    Runs a real-time simulation loop for a synchronous simulation environment.
+	Runs a real-time simulation loop for a synchronous simulation environment.
 
-    The loop advances the simulation world in fixed time steps determined by
-    `target_time_scale`, maintaining real-time pacing. It adjusts for timing
-    and can optionally resynchronize if the simulation falls behind.
+	The loop advances the simulation world in fixed time steps determined by
+	`target_time_scale`, maintaining real-time pacing. It adjusts for timing
+	and can optionally resynchronize if the simulation falls behind.
 
-    Notes
-    -----
-    - This function runs indefinitely until interrupted (e.g., with Ctrl+C).
-    - When interrupted, it restores the world to asynchronous mode to prevent crashes.
+	Notes
+	-----
+	- This function runs indefinitely until interrupted (e.g., with Ctrl+C).
+	- When interrupted, it restores the world to asynchronous mode to prevent crashes.
 
-    :param world: The simulation world instance.
-    :param ego: The main vehicle actor - player pawn.
-    :param target_time_scale: The simulation speed multiplier. Higher values make the simulation run faster, and lower to run slower relative to real time (2.0 = twice real-time speed, 0.5 = half the real-time speed).
-    :param acceptable_lag: The maximum acceptable lag. If the loop falls behind by more than this value, a warning is logged.
-    :param should_resync: If True, the simulation will resynchronize to the current time when lag exceeds the acceptable threshold.
-    :param follow_ego: If True, moves the spectator camera to follow the ego actor each tick.
-    """
+	:param world: The simulation world instance.
+	:param ego: The main vehicle actor - player pawn.
+	:param target_time_scale: The simulation speed multiplier. Higher values make the simulation run faster, and lower to run slower relative to real time (2.0 = twice real-time speed, 0.5 = half the real-time speed).
+	:param acceptable_lag: The maximum acceptable lag. If the loop falls behind by more than this value, a warning is logged.
+	:param should_resync: If True, the simulation will resynchronize to the current time when lag exceeds the acceptable threshold.
+	:param follow_ego: If True, moves the spectator camera to follow the ego actor each tick.
+	"""
 
-    real_dt = SIM_DT / target_time_scale
+    real_dt = target_sim_dt / target_time_scale
     frame_count = 0
     next_tick_time = time.time()
 
@@ -399,9 +414,10 @@ def run_simulation_loop(world, target_time_scale=1.0, acceptable_lag=0.05, shoul
                     next_tick_time = time.time()
 
     except KeyboardInterrupt:
-        log_info("Exiting simulation loop, restoring asynchronous mode...")
+        log_info("Exiting simulation loop, restoring default Carla mode (asynchronous mode + variable time step)")
         settings = world.get_settings()
         settings.synchronous_mode = False
+        settings.fixed_delta_seconds = None
         world.apply_settings(settings)
 
 
@@ -427,8 +443,14 @@ def main():
         '--resync_mode', action='store_true',
         help='Resynchronize to the current time when lag exceeds the acceptable threshold')
     argparser.add_argument(
-    	'--load_map', nargs='?', const='Town10HD_Opt',
-    	help='Load the provided map')
+        '--load_map', nargs='?', const='Town10HD_Opt',
+        help='Load the provided map')
+    argparser.add_argument(
+        '--async_run', action='store_true',
+        help='Run the server and client in asynchronous mode.')
+    argparser.add_argument(
+        '--hz_rate', nargs=int, const=100,
+        help='Set None for variable time step, otherwise fixed time step will be used with target hz rate.')
     args = argparser.parse_args()
 
     # Get Client info
@@ -439,9 +461,12 @@ def main():
     # Determine which map to load
     map_name = args.load_map if args.load_map is not None else 'Town10HD_Opt'
 
+    # Determine TimeStep Data to be used
+    time_step_info = TimeStepData(synchronous_mode=negate(args.async_run), hz_rate=args.hz_rate)
+
     # Apply Settings
-    apply_world_settings(client, world, map_name)
-    log_info("Simulation time scale is %f" % args.time_scale)
+    apply_world_settings(client=client, world=world, TimeStepData=time_step_info, map_name=map_name)
+    log_info("Simulation time scale: %f, fixed time step: %s, running in synchronous mode: %s" % args.time_scale % time_step_info.hz_rate % time_step_info.synchronous_mode)
 
     # Spawn Ego
     spawn_point = random.choice(world.get_map().get_spawn_points())
@@ -454,7 +479,12 @@ def main():
     log_warning('Kill this script before stopping simulation!')
 
     # Run simulation loop
-    run_simulation_loop(target_time_scale=args.time_scale, follow_ego=True, world=world, ego=ego, should_resync=args.resync_mode)
+    run_simulation_loop(target_sim_dt=time_step_info.get_sim_dt(),
+                        target_time_scale=args.time_scale,
+                        should_resync=args.resync_mode,
+                        follow_ego=args.follow,
+                        world=world,
+                        ego=ego)
 
 
 if __name__ == '__main__':

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -360,13 +360,13 @@ def apply_world_settings(client, world, time_step_info, map_name=None):
         False)  # Autoware will be publishing TF information based on the URDF files of the vehicle and sensor kit.
 
 
-def run_simulation_loop(world,
-                        target_time_scale=1.0,
-                        acceptable_lag=0.05,
-                        should_resync=False,
-                        ego=None,
-                        follow_ego=False,
-                        target_sim_dt=0.01):
+def run_sync_simulation_loop(world,
+                             target_time_scale=1.0,
+                             acceptable_lag=0.05,
+                             should_resync=False,
+                             ego=None,
+                             follow_ego=False,
+                             target_sim_dt=0.01):
     """
 	Runs a real-time simulation loop for a synchronous simulation environment.
 
@@ -381,11 +381,17 @@ def run_simulation_loop(world,
 
 	:param world: The simulation world instance.
 	:param ego: The main vehicle actor - player pawn.
-	:param target_time_scale: The simulation speed multiplier. Higher values make the simulation run faster, and lower to run slower relative to real time (2.0 = twice real-time speed, 0.5 = half the real-time speed).
-	:param acceptable_lag: The maximum acceptable delay in seconds between real time and simulation time. If the loop falls behind by more than this value, a warning is logged.
-	:param should_resync: If True, when lag exceeds the acceptable threshold, the loop resets its internal schedule to the current wall time, causing the next tick to run immediately to catch up to real time.
+	:param target_time_scale: The simulation speed multiplier.
+	    Higher values make the simulation run faster, and lower to run slower relative to real time
+	    (2.0 = twice real-time speed, 0.5 = half the real-time speed).
+	:param acceptable_lag: The maximum acceptable delay in seconds between real time and simulation time.
+	    If the loop falls behind by more than this value, a warning is logged.
+	:param should_resync: If True, when lag exceeds the acceptable threshold,
+	    the loop resets its internal schedule to the current wall time,
+	    causing the next tick to run immediately to catch up to real time.
 	:param follow_ego: If True, moves the spectator camera to follow the ego actor each tick.
-	:param target_sim_dt: Fixed simulation step (in seconds). Used together with `target_time_scale` to determine real-time pacing between ticks.
+	:param target_sim_dt: Fixed simulation step (in seconds).
+	    Used together with `target_time_scale` to determine real-time pacing between ticks.
 	"""
 
     real_dt = target_sim_dt / target_time_scale
@@ -517,12 +523,12 @@ def main():
     log_warning('Kill this script before stopping simulation!')
 
     # Run simulation loop
-    run_simulation_loop(target_sim_dt=time_step_info.get_sim_dt(),
-                        target_time_scale=args.time_scale,
-                        should_resync=args.resync_mode,
-                        follow_ego=args.follow,
-                        world=world,
-                        ego=ego)
+    time_step_info.synchronous_mode and run_sync_simulation_loop(target_sim_dt=time_step_info.get_sim_dt(),
+                                                                 target_time_scale=args.time_scale,
+                                                                 should_resync=args.resync_mode,
+                                                                 follow_ego=args.follow,
+                                                                 world=world,
+                                                                 ego=ego)
 
 
 if __name__ == '__main__':

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -305,9 +305,12 @@ def move_spectator(world, ego_vehicle):
 
 def apply_world_settings(client, world, map_name="Town10HD_Opt"):
     """
+    Stores all settings related to the simulation world.
     Applies Synchronous mode + fixed time-step into world settings.
 
-    Store here all settings related to simulation world.
+    :param client: Connected client to the Carla server instance.
+    :param world: The simulation world instance.
+    :param map_name: Map to load and apply settings to.
     """
 
     # Load the desired map

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -543,13 +543,14 @@ def main():
     log_info('Ego spawned!')
     log_warning('Kill this script before stopping simulation!')
 
-    # Run simulation loop
-    time_step_info.synchronous_mode and run_sync_simulation_loop(target_sim_dt=time_step_info.get_sim_dt(),
-                                                                 target_time_scale=args.time_scale,
-                                                                 should_resync=args.resync,
-                                                                 follow_ego=args.follow,
-                                                                 world=world,
-                                                                 ego=ego)
+    # Run synchronous simulation loop
+    if time_step_info.synchronous_mode:
+        run_sync_simulation_loop(target_sim_dt=time_step_info.get_sim_dt(),
+                                 target_time_scale=args.time_scale,
+                                 should_resync=args.resync,
+                                 follow_ego=args.follow,
+                                 world=world,
+                                 ego=ego)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## About
> [!IMPORTANT]
> Merge first #35 into the main branch and then proceed with merging #37.

This PR contains several improvements and features:
- map loading from arguments
- setting synchronized mode from arguments
- setting simulation hz rate from arguments
- setting physics substepping from arguments
- setting resynchronization for sync mode from arguments
- forcing map reload from arguments
- improved docstrings

## Key changes
- removed globally defined static variables for simulation time
- all values are passed from arguments, if none are provided, the script uses the default argument values 
- default settings are targeting pure step execution (synchronous mode, 100Hz, disabled physics substepping)
- code is structured into function blocks, to make it more reusable 
- automatically apply settings based on configuration
- verify if the provided settings can be achieved
- reformatted code with Python standards
- splitted docstrings into multiple lines

## Usage
By default, pure step execution is applied (synchronous mode, 100Hz, disabled physics substepping).
```bash
python3 autoware_demo.py
```
> [!NOTE]
> If synchronous mode is used, then and only then function `run_sync_simulation_loop()` is called.

### Async mode
By default script set's `async = false`. If running with flag `--run_async` makes this variable set to `true`.
> [!IMPORTANT]
> Using `--resync` only works with synchronous mode. 
> Either run `--async` or `--resync`. Combining both flags together will make `resync` do nothing. 

### Fixed time step
By default, simulation runs in a fixed time step of 100Hz (0.01 seconds).
To change the fixed time step:
```bash
python3 autoware_demo.py --hz_rate <new_hz_rate>
```

### Variable time step
To enable a variable time step, `settings.fixed_time_step` must be set to `None`. 
This can be achieved by setting the Hz rate in the argument as:
```bash
python3 autoware_demo.py --hz_rate 0 # 0 is parsed as None for fixed_time_step
python3 autoware_demo.py --hz_rate None # None string is parsed as None for fixed_time_step
python3 autoware_demo.py --hz_rate # empty string is parsed as None for fixed_time_step
```

### Map
By default, the script is using the default Carla showcase map of `Town10HD_Opt`.
To change it:
```bash
python3 autoware_demo.py --load_map <string_map_name>
```



