### PR TITLE
Add vehicle acceleration I/O and ROS2 acceleration message support

### DIFF
--- a/LibCarla/source/carla/client/Actor.cpp
+++ b/LibCarla/source/carla/client/Actor.cpp
@@ -66,6 +66,14 @@ namespace client {
     GetEpisode().Lock()->DisableActorConstantVelocity(*this);
   }
 
+  void Actor::EnableConstantAcceleration(const geom::Vector3D &vector) {
+    GetEpisode().Lock()->EnableActorConstantAcceleration(*this, vector);
+  }
+
+  void Actor::DisableConstantAcceleration() {
+    GetEpisode().Lock()->DisableActorConstantAcceleration(*this);
+  }
+
   void Actor::AddImpulse(const geom::Vector3D &impulse) {
     GetEpisode().Lock()->AddActorImpulse(*this, impulse);
   }

--- a/LibCarla/source/carla/client/Actor.h
+++ b/LibCarla/source/carla/client/Actor.h
@@ -90,6 +90,12 @@ namespace client {
     /// Disable the constant velocity mode
     void DisableConstantVelocity();
 
+    /// Enable a constant acceleration mode (direct acceleration, no pedal input)
+    void EnableConstantAcceleration(const geom::Vector3D &vector);
+
+    /// Disable the constant acceleration mode
+    void DisableConstantAcceleration();
+
     /// Add impulse to the actor at its center of mass.
     void AddImpulse(const geom::Vector3D &vector);
 

--- a/LibCarla/source/carla/client/detail/Client.cpp
+++ b/LibCarla/source/carla/client/detail/Client.cpp
@@ -416,6 +416,14 @@ namespace detail {
     _pimpl->AsyncCall("disable_actor_constant_velocity", actor);
   }
 
+  void Client::EnableActorConstantAcceleration(rpc::ActorId actor, const geom::Vector3D &vector) {
+    _pimpl->AsyncCall("enable_actor_constant_acceleration", actor, vector);
+  }
+
+  void Client::DisableActorConstantAcceleration(rpc::ActorId actor) {
+    _pimpl->AsyncCall("disable_actor_constant_acceleration", actor);
+  }
+
   void Client::AddActorImpulse(rpc::ActorId actor, const geom::Vector3D &impulse) {
     _pimpl->AsyncCall("add_actor_impulse", actor, impulse);
   }

--- a/LibCarla/source/carla/client/detail/Client.h
+++ b/LibCarla/source/carla/client/detail/Client.h
@@ -226,6 +226,13 @@ namespace detail {
     void DisableActorConstantVelocity(
         rpc::ActorId actor);
 
+    void EnableActorConstantAcceleration(
+        rpc::ActorId actor,
+        const geom::Vector3D &vector);
+
+    void DisableActorConstantAcceleration(
+        rpc::ActorId actor);
+
     void AddActorImpulse(
         rpc::ActorId actor,
         const geom::Vector3D &impulse);

--- a/LibCarla/source/carla/client/detail/Simulator.h
+++ b/LibCarla/source/carla/client/detail/Simulator.h
@@ -430,6 +430,14 @@ namespace detail {
       _client.DisableActorConstantVelocity(actor.GetId());
     }
 
+    void EnableActorConstantAcceleration(const Actor &actor, const geom::Vector3D &vector) {
+      _client.EnableActorConstantAcceleration(actor.GetId(), vector);
+    }
+
+    void DisableActorConstantAcceleration(const Actor &actor) {
+      _client.DisableActorConstantAcceleration(actor.GetId());
+    }
+
     void AddActorImpulse(const Actor &actor, const geom::Vector3D &impulse) {
       _client.AddActorImpulse(actor.GetId(), impulse);
     }

--- a/LibCarla/source/carla/ros2/ROS2.cpp
+++ b/LibCarla/source/carla/ros2/ROS2.cpp
@@ -118,13 +118,13 @@ void ROS2::SetFrame(uint64_t frame) {
       RemoveActorCallback(actor);
     }
    }
-  if (_autoware_controller) {  // Autoware input has priority
+  if (_autoware_controller) {  // Autoware input has priority (acceleration control from /control/command/control_cmd)
     void* actor = _autoware_controller->GetVehicle();
     if (_autoware_controller->HasNewControl()) {
       auto it = _actor_callbacks.find(actor);
       if (it != _actor_callbacks.cend()) {
         const auto control = _autoware_controller->GetControl();
-        it->second(actor, control);
+        it->second(actor, ROS2CallbackData(control));
       }
     }
   }

--- a/LibCarla/source/carla/ros2/ROS2CallbackData.h
+++ b/LibCarla/source/carla/ros2/ROS2CallbackData.h
@@ -32,12 +32,20 @@ namespace ros2 {
     float jerk;
   };
 
+  /// Control from /control/command/control_cmd: longitudinal acceleration [m/s^2] + steering
+  struct VehicleAccelerationControl
+  {
+    float acceleration;
+    float steer;
+    float steer_speed;
+  };
+
     struct MessageControl
   {
     const char* message;
   };
 
-  using ROS2CallbackData = std::variant<VehicleControl, VehicleAckermannControl>;
+  using ROS2CallbackData = std::variant<VehicleControl, VehicleAckermannControl, VehicleAccelerationControl>;
   using ROS2MessageCallbackData = std::variant<MessageControl>;
 
   using ActorCallback = std::function<void(void *actor, ROS2CallbackData data)>;

--- a/LibCarla/source/carla/ros2/subscribers/AutowareController.cpp
+++ b/LibCarla/source/carla/ros2/subscribers/AutowareController.cpp
@@ -14,7 +14,6 @@
 #include "carla/ros2/types/EngagePubSubTypes.h"
 
 #include "carla/ros2/subscribers/AutowareSubscriber.h"
-#include "carla/ros2/AutowareSteeringCompensation.h"
 
 #include <algorithm>
 #include <cmath>
@@ -144,8 +143,8 @@ bool AutowareController::HasNewControl() const {
          _impl->_engage_subscriber.HasNewMessage();
 }
 
-VehicleAckermannControl AutowareController::GetControl() {
-  VehicleAckermannControl control_out;
+VehicleAccelerationControl AutowareController::GetControl() {
+  VehicleAccelerationControl control_out{};
 
   const auto control_in = _impl->_control_subscriber.GetMessage();
   const auto gear_in = _impl->_gear_subscriber.GetMessage();
@@ -190,20 +189,17 @@ VehicleAckermannControl AutowareController::GetControl() {
       << std::endl;
   }
 
-  control_out.speed = control_in.longitudinal().velocity();
-  if (control_in.longitudinal().is_defined_acceleration()) {
-    control_out.acceleration = control_in.longitudinal().acceleration();
-  }
-  if (control_in.longitudinal().is_defined_jerk()) {
-    control_out.jerk = control_in.longitudinal().jerk();
-  }
+  // Longitudinal: use ONLY acceleration from /control/command/control_cmd to drive the vehicle.
+  // Velocity and jerk from the message are intentionally ignored.
+  control_out.acceleration = control_in.longitudinal().acceleration();
 
   /// @note Set lateral negative, because Carla treats positive as right and Autoware expects positive to represent left (all when moving forward)
   const auto raw_steering = -control_in.lateral().steering_tire_angle();
 
-  // Apply steering compensation using lookup table
-  control_out.steer = autoware_steering_compensation::GetSteeringInput(raw_steering);
-
+  // Autoware publishes steering_tire_angle [rad] (front wheel angle).
+  // We reuse the same convention as Ackermann: pass tire angle as steering.
+  control_out.steer = raw_steering;
+  control_out.steer_speed = 0.0f;
   if (control_in.lateral().is_defined_steering_tire_rotation_rate()) {
     control_out.steer_speed = -control_in.lateral().steering_tire_rotation_rate();
   }

--- a/LibCarla/source/carla/ros2/subscribers/AutowareController.h
+++ b/LibCarla/source/carla/ros2/subscribers/AutowareController.h
@@ -17,7 +17,7 @@ public:
 
   bool HasNewControl() const;
 
-  VehicleAckermannControl GetControl();
+  VehicleAccelerationControl GetControl();
   void* GetVehicle();
 
 private:

--- a/PythonAPI/carla/src/Actor.cpp
+++ b/PythonAPI/carla/src/Actor.cpp
@@ -119,6 +119,8 @@ void export_actor() {
       .def("set_target_angular_velocity", &cc::Actor::SetTargetAngularVelocity, (arg("angular_velocity")))
       .def("enable_constant_velocity", &cc::Actor::EnableConstantVelocity, (arg("velocity")))
       .def("disable_constant_velocity", &cc::Actor::DisableConstantVelocity)
+      .def("enable_constant_acceleration", &cc::Actor::EnableConstantAcceleration, (arg("acceleration")))
+      .def("disable_constant_acceleration", &cc::Actor::DisableConstantAcceleration)
       .def("add_impulse", &AddActorImpulse, (arg("impulse")))
       .def("add_force", &AddActorForce, (arg("force")))
       .def("add_angular_impulse", &cc::Actor::AddAngularImpulse, (arg("angular_impulse")))

--- a/PythonAPI/examples/autoware_demo.py
+++ b/PythonAPI/examples/autoware_demo.py
@@ -282,7 +282,8 @@ def spawn_ego_with_sensors(world, spawn_point, args):
 
     ego_blueprint = blueprint_library.find("vehicle.lincoln.mkz")
     ego_blueprint.set_attribute("role_name", "ego")
-    ego_blueprint.set_attribute("ros_topic_name", "/carla/input")  # Default Carla ROS input topic name
+    # Ego uses acceleration control from Autoware /control/command/control_cmd (not ackermann)
+    ego_blueprint.set_attribute("ros_topic_name", "/carla/input")  # Fallback; Autoware control_cmd has priority
 
     ego = world.spawn_actor(ego_blueprint, spawn_point)
 
@@ -572,7 +573,14 @@ def main():
 
 
     # Spawn Ego
-    spawn_point = random.choice(world.get_ego_spawn_points())
+    try:
+        spawn_points = world.get_ego_spawn_points()
+    except AttributeError:
+        # Fallback when get_ego_spawn_points is not available (e.g. standard carla package)
+        spawn_points = world.get_map().get_spawn_points()
+    if not spawn_points:
+        raise RuntimeError("No spawn points available. Load a map that provides spawn points.")
+    spawn_point = random.choice(spawn_points)
     ego = spawn_ego_with_sensors(world, spawn_point, args)
 
     world.tick()  # tick to process the changes (settings, ego + sensors spawn)

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.cpp
@@ -46,6 +46,17 @@ void ActorROS2Handler::operator()(carla::ros2::VehicleAckermannControl &Source)
   Vehicle->ApplyVehicleAckermannControl(NewControl, EVehicleInputPriority::User);
 }
 
+void ActorROS2Handler::operator()(carla::ros2::VehicleAccelerationControl &Source)
+{
+  if (!IsValid(_Actor)) return;
+
+  ACarlaWheeledVehicle *Vehicle = Cast<ACarlaWheeledVehicle>(_Actor);
+  if (!IsValid(Vehicle)) return;
+
+  // /control/command/control_cmd: use acceleration [m/s^2] + steering for acceleration control
+  Vehicle->ApplyVehicleAccelerationControl(Source.acceleration, Source.steer, Source.steer_speed);
+}
+
 void ActorROS2Handler::operator()(carla::ros2::MessageControl Message)
 {
   if (!IsValid(_Actor)) return;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/ActorROS2Handler.h
@@ -19,6 +19,7 @@ class ActorROS2Handler
 
         void operator()(carla::ros2::VehicleControl &Source);
         void operator()(carla::ros2::VehicleAckermannControl &Source);
+        void operator()(carla::ros2::VehicleAccelerationControl &Source);
         void operator()(carla::ros2::MessageControl Message);
 
         static bool FlattenSteeringCurve(AActor * Actor);

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/CarlaActor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/CarlaActor.cpp
@@ -646,6 +646,40 @@ ECarlaServerResponse FVehicleActor::DisableActorConstantVelocity()
   return ECarlaServerResponse::Success;
 }
 
+ECarlaServerResponse FVehicleActor::EnableActorConstantAcceleration(const FVector& Acceleration)
+{
+  if (IsDormant())
+  {
+  }
+  else
+  {
+    auto CarlaVehicle = Cast<ACarlaWheeledVehicle>(GetActor());
+    if (CarlaVehicle == nullptr)
+    {
+      return ECarlaServerResponse::NullActor;
+    }
+    CarlaVehicle->ActivateAccelerationControl(Acceleration);
+  }
+  return ECarlaServerResponse::Success;
+}
+
+ECarlaServerResponse FVehicleActor::DisableActorConstantAcceleration()
+{
+  if (IsDormant())
+  {
+  }
+  else
+  {
+    auto CarlaVehicle = Cast<ACarlaWheeledVehicle>(GetActor());
+    if (CarlaVehicle == nullptr)
+    {
+      return ECarlaServerResponse::NullActor;
+    }
+    CarlaVehicle->DeactivateAccelerationControl();
+  }
+  return ECarlaServerResponse::Success;
+}
+
 ECarlaServerResponse FVehicleActor::GetPhysicsControl(FVehiclePhysicsControl& PhysicsControl)
 {
   if (IsDormant())

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/CarlaActor.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Actor/CarlaActor.h
@@ -241,6 +241,16 @@ public:
     return ECarlaServerResponse::ActorTypeMismatch;
   }
 
+  virtual ECarlaServerResponse EnableActorConstantAcceleration(const FVector&)
+  {
+    return ECarlaServerResponse::ActorTypeMismatch;
+  }
+
+  virtual ECarlaServerResponse DisableActorConstantAcceleration()
+  {
+    return ECarlaServerResponse::ActorTypeMismatch;
+  }
+
   virtual ECarlaServerResponse GetPhysicsControl(FVehiclePhysicsControl&)
   {
     return ECarlaServerResponse::ActorTypeMismatch;
@@ -482,6 +492,10 @@ public:
   virtual ECarlaServerResponse EnableActorConstantVelocity(const FVector& Velocity) final;
 
   virtual ECarlaServerResponse DisableActorConstantVelocity() final;
+
+  virtual ECarlaServerResponse EnableActorConstantAcceleration(const FVector& Acceleration) final;
+
+  virtual ECarlaServerResponse DisableActorConstantAcceleration() final;
 
   virtual ECarlaServerResponse GetPhysicsControl(FVehiclePhysicsControl& PhysicsControl) final;
 

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1220,6 +1220,59 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     return R<void>::Success();
   };
 
+  BIND_SYNC(enable_actor_constant_acceleration) << [this](
+      cr::ActorId ActorId,
+      cr::Vector3D vector) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
+    if (!CarlaActor)
+    {
+      return RespondError(
+          "enable_actor_constant_acceleration",
+          ECarlaServerResponse::ActorNotFound,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+
+    ECarlaServerResponse Response =
+        CarlaActor->EnableActorConstantAcceleration(vector.ToCentimeters().ToFVector());
+    if (Response != ECarlaServerResponse::Success)
+    {
+      return RespondError(
+          "enable_actor_constant_acceleration",
+          Response,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+
+    return R<void>::Success();
+  };
+
+  BIND_SYNC(disable_actor_constant_acceleration) << [this](
+      cr::ActorId ActorId) -> R<void>
+  {
+    REQUIRE_CARLA_EPISODE();
+    FCarlaActor* CarlaActor = Episode->FindCarlaActor(ActorId);
+    if (!CarlaActor)
+    {
+      return RespondError(
+          "disable_actor_constant_acceleration",
+          ECarlaServerResponse::ActorNotFound,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+
+    ECarlaServerResponse Response =
+        CarlaActor->DisableActorConstantAcceleration();
+    if (Response != ECarlaServerResponse::Success)
+    {
+      return RespondError(
+          "disable_actor_constant_acceleration",
+          Response,
+          " Actor Id: " + FString::FromInt(ActorId));
+    }
+
+    return R<void>::Success();
+  };
+
   BIND_SYNC(add_actor_impulse) << [this](
       cr::ActorId ActorId,
       cr::Vector3D vector) -> R<void>

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.cpp
@@ -50,6 +50,9 @@ ACarlaWheeledVehicle::ACarlaWheeledVehicle(const FObjectInitializer& ObjectIniti
   VelocityControl = CreateDefaultSubobject<UVehicleVelocityControl>(TEXT("VelocityControl"));
   VelocityControl->Deactivate();
 
+  AccelerationControl = CreateDefaultSubobject<UVehicleAccelerationControl>(TEXT("AccelerationControl"));
+  AccelerationControl->Deactivate();
+
   GetChaosWheeledVehicleMovementComponent()->bReverseAsBrake = false;
   BaseMovementComponent = CreateDefaultSubobject<UBaseCarlaMovementComponent>(TEXT("BaseMovementComponent"));
 
@@ -165,6 +168,12 @@ void ACarlaWheeledVehicle::BeginPlay()
 
 void ACarlaWheeledVehicle::TickActor(float DeltaTime, enum ELevelTick TickType, FActorTickFunction& ThisTickFunction){
   Super::TickActor(DeltaTime, TickType, ThisTickFunction);
+
+  // When velocity/acceleration control is active, flush control every frame even without AI controller
+  if (VelocityControl->IsActive() || AccelerationControl->IsActive())
+  {
+    FlushVehicleControl();
+  }
 
   FPoseSnapshot pose;
   GetMesh()->SnapshotPose(pose);
@@ -655,6 +664,34 @@ void ACarlaWheeledVehicle::DeactivateVelocityControl()
 {
   VelocityControl->Deactivate();
 }
+
+void ACarlaWheeledVehicle::ActivateAccelerationControl(const FVector& Acceleration)
+{
+  AccelerationControl->Activate(Acceleration);
+}
+
+void ACarlaWheeledVehicle::DeactivateAccelerationControl()
+{
+  AccelerationControl->Deactivate();
+}
+
+void ACarlaWheeledVehicle::ApplyVehicleAccelerationControl(float LongitudinalAccelerationMps2, float Steer, float SteerSpeed)
+{
+  if (bAckermannControlActive)
+  {
+    AckermannController.Reset();
+  }
+  bAckermannControlActive = false;
+  VelocityControl->Deactivate();
+
+  // Longitudinal: acceleration from control_cmd [m/s^2] -> Unreal uses cm/s^2
+  const FVector AccelerationCmps2(LongitudinalAccelerationMps2 * 100.0f, 0.0f, 0.0f);
+  AccelerationControl->Activate(AccelerationCmps2);
+
+  InputControl.Control.Steer = Steer;
+  InputControl.Priority = EVehicleInputPriority::User;
+}
+
 
 void ACarlaWheeledVehicle::ShowDebugTelemetry(bool Enabled)
 {

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/CarlaWheeledVehicle.h
@@ -15,6 +15,7 @@
 #include "Carla/Vehicle/VehicleInputPriority.h"
 #include "Carla/Vehicle/VehiclePhysicsControl.h"
 #include "Carla/Vehicle/VehicleVelocityControl.h"
+#include "Carla/Vehicle/VehicleAccelerationControl.h"
 #include "Carla/Vehicle/WheeledVehicleMovementComponentNW.h"
 #include "Carla/Vehicle/MovementComponents/BaseCarlaMovementComponent.h"
 
@@ -238,6 +239,15 @@ public:
   void DeactivateVelocityControl();
 
   UFUNCTION(Category = "CARLA Wheeled Vehicle", BlueprintCallable)
+  void ActivateAccelerationControl(const FVector &Acceleration);
+
+  UFUNCTION(Category = "CARLA Wheeled Vehicle", BlueprintCallable)
+  void DeactivateAccelerationControl();
+
+  /// Apply control from Autoware /control/command/control_cmd (acceleration [m/s^2] + steering)
+  void ApplyVehicleAccelerationControl(float LongitudinalAccelerationMps2, float Steer, float SteerSpeed);
+
+  UFUNCTION(Category = "CARLA Wheeled Vehicle", BlueprintCallable)
   void ShowDebugTelemetry(bool Enabled);
 
   /// @todo This function should be private to AWheeledVehicleAIController.
@@ -339,6 +349,9 @@ private:
 
   UPROPERTY(Category = "CARLA Wheeled Vehicle", EditAnywhere)
   UVehicleVelocityControl* VelocityControl;
+
+  UPROPERTY(Category = "CARLA Wheeled Vehicle", EditAnywhere)
+  UVehicleAccelerationControl* AccelerationControl;
 
 
   FVehicleControl LastAppliedControl;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleAccelerationControl.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleAccelerationControl.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) 2026 TIER IV, Inc.
 
+// TODO: Add gear-aware input (e.g. allow reverse when in reverse gear, keep forward-only in drive).
+
 #include "VehicleAccelerationControl.h"
 #include "Carla/Vehicle/CarlaWheeledVehicle.h"
 
@@ -78,6 +80,9 @@ void UVehicleAccelerationControl::TickComponent(float DeltaTime, enum ELevelTick
 
   // Integrate only forward speed; preserve lateral velocity from physics so tires can generate cornering force
   ControlledForwardSpeed += ForwardAccel * DeltaTime;
+  // Clamp to non-negative so we never go into reverse
+  // TODO: Add gear-aware input (e.g. allow reverse when in reverse gear, keep forward-only in drive).
+  ControlledForwardSpeed = FMath::Max(0.f, ControlledForwardSpeed);
 
   const FVector CurrentVel = PrimitiveComponent->GetPhysicsLinearVelocity();
   const FVector LateralVel = CurrentVel - FVector::DotProduct(CurrentVel, ForwardDir) * ForwardDir;

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleAccelerationControl.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleAccelerationControl.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 TIER IV, Inc.
+
+#include "VehicleAccelerationControl.h"
+#include "Carla/Vehicle/CarlaWheeledVehicle.h"
+
+UVehicleAccelerationControl::UVehicleAccelerationControl()
+{
+  PrimaryComponentTick.bCanEverTick = true;
+}
+
+void UVehicleAccelerationControl::BeginPlay()
+{
+  Super::BeginPlay();
+
+  SetComponentTickEnabled(false);
+  // Run after physics so our velocity override is applied after the vehicle simulation
+  SetTickGroup(ETickingGroup::TG_PostPhysics);
+
+  OwnerVehicle = GetOwner();
+  ACarlaWheeledVehicle* CarlaVehicle = Cast<ACarlaWheeledVehicle>(OwnerVehicle);
+  if (CarlaVehicle && CarlaVehicle->GetMesh())
+  {
+    PrimitiveComponent = Cast<UPrimitiveComponent>(CarlaVehicle->GetMesh());
+  }
+  if (PrimitiveComponent == nullptr)
+  {
+    PrimitiveComponent = Cast<UPrimitiveComponent>(OwnerVehicle->GetRootComponent());
+  }
+  ControlledForwardSpeed = 0.f;
+}
+
+void UVehicleAccelerationControl::Activate(bool bReset)
+{
+  Super::Activate(bReset);
+
+  TargetAcceleration = FVector();
+  SetComponentTickEnabled(true);
+}
+
+void UVehicleAccelerationControl::Activate(FVector Acceleration, bool bReset)
+{
+  Super::Activate(bReset);
+
+  TargetAcceleration = Acceleration;
+  if (PrimitiveComponent != nullptr)
+  {
+    const FVector Vel = PrimitiveComponent->GetPhysicsLinearVelocity();
+    const FVector Forward = OwnerVehicle->GetActorTransform().TransformVectorNoScale(FVector(1, 0, 0));
+    const FVector ForwardDir = Forward.GetSafeNormal();
+    ControlledForwardSpeed = FVector::DotProduct(Vel, ForwardDir);
+  }
+  else
+  {
+    ControlledForwardSpeed = 0.f;
+  }
+  SetComponentTickEnabled(true);
+}
+
+void UVehicleAccelerationControl::Deactivate()
+{
+  SetComponentTickEnabled(false);
+  Super::Deactivate();
+}
+
+void UVehicleAccelerationControl::TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction *ThisTickFunction)
+{
+  TRACE_CPUPROFILER_EVENT_SCOPE(UVehicleAccelerationControl::TickComponent);
+  if (PrimitiveComponent == nullptr)
+  {
+    return;
+  }
+  PrimitiveComponent->WakeRigidBody(NAME_None);
+
+  const FTransform Transf = OwnerVehicle->GetActorTransform();
+  const FVector ForwardDir = Transf.TransformVectorNoScale(FVector(1, 0, 0)).GetSafeNormal();
+  const FVector WorldAcceleration = Transf.TransformVector(TargetAcceleration);
+  const float ForwardAccel = FVector::DotProduct(WorldAcceleration, ForwardDir);
+
+  // Integrate only forward speed; preserve lateral velocity from physics so tires can generate cornering force
+  ControlledForwardSpeed += ForwardAccel * DeltaTime;
+
+  const FVector CurrentVel = PrimitiveComponent->GetPhysicsLinearVelocity();
+  const FVector LateralVel = CurrentVel - FVector::DotProduct(CurrentVel, ForwardDir) * ForwardDir;
+  const FVector NewVel = (ControlledForwardSpeed * ForwardDir) + LateralVel;
+
+  PrimitiveComponent->SetPhysicsLinearVelocity(NewVel, false, "None");
+}

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleAccelerationControl.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleAccelerationControl.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 TIER IV, Inc.
+
+#pragma once
+
+#include <util/ue-header-guard-begin.h>
+#include "Components/ActorComponent.h"
+#include "Components/PrimitiveComponent.h"
+#include "CoreMinimal.h"
+#include <util/ue-header-guard-end.h>
+
+#include "VehicleAccelerationControl.generated.h"
+
+/// Component that controls the actor with a constant acceleration (directly applied,
+/// no pedal input). Similar to VehicleVelocityControl but for acceleration.
+UCLASS(Blueprintable, BlueprintType, ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class CARLA_API UVehicleAccelerationControl : public UActorComponent
+{
+  GENERATED_BODY()
+
+  // ===========================================================================
+  /// @name Constructor and destructor
+  // ===========================================================================
+  /// @{
+public:
+  UVehicleAccelerationControl();
+
+  /// @}
+  // ===========================================================================
+  /// @name Get functions
+  // ===========================================================================
+  /// @{
+public:
+
+  void BeginPlay() override;
+
+  virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction *ThisTickFunction) override;
+
+  // Activate the component setting the target acceleration
+  virtual void Activate(bool bReset=false) override;
+
+  // Activate the component setting the target acceleration (in vehicle local space, e.g. X=forward)
+  virtual void Activate(FVector Acceleration, bool bReset=false);
+
+  // Deactivate the component
+  virtual void Deactivate() override;
+
+private:
+  // Target acceleration in vehicle local space (e.g. X forward, Y right, Z up). Units: cm/s^2
+  UPROPERTY(Category = "Vehicle Acceleration Control", VisibleAnywhere)
+  FVector TargetAcceleration;
+
+  /// Integrated forward speed [cm/s] under our control; lateral component is left to physics for cornering
+  float ControlledForwardSpeed;
+
+  UPrimitiveComponent* PrimitiveComponent;
+  AActor* OwnerVehicle;
+
+};

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleVelocityControl.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Vehicle/VehicleVelocityControl.cpp
@@ -5,6 +5,7 @@
 // For a copy, see <https://opensource.org/licenses/MIT>.
 
 #include "VehicleVelocityControl.h"
+#include "Carla/Vehicle/CarlaWheeledVehicle.h"
 
 #include <util/ue-header-guard-begin.h>
 #include "Kismet/KismetMathLibrary.h"
@@ -23,7 +24,15 @@ void UVehicleVelocityControl::BeginPlay()
   SetTickGroup(ETickingGroup::TG_PrePhysics);
 
   OwnerVehicle = GetOwner();
-  PrimitiveComponent = Cast<UPrimitiveComponent>(OwnerVehicle->GetRootComponent());
+  ACarlaWheeledVehicle* CarlaVehicle = Cast<ACarlaWheeledVehicle>(OwnerVehicle);
+  if (CarlaVehicle && CarlaVehicle->GetMesh())
+  {
+    PrimitiveComponent = Cast<UPrimitiveComponent>(CarlaVehicle->GetMesh());
+  }
+  if (PrimitiveComponent == nullptr)
+  {
+    PrimitiveComponent = Cast<UPrimitiveComponent>(OwnerVehicle->GetRootComponent());
+  }
 }
 
 void UVehicleVelocityControl::Activate(bool bReset)
@@ -51,6 +60,11 @@ void UVehicleVelocityControl::Deactivate()
 void UVehicleVelocityControl::TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction *ThisTickFunction)
 {
   TRACE_CPUPROFILER_EVENT_SCOPE(UVehicleVelocityControl::TickComponent);
+  if (PrimitiveComponent == nullptr)
+  {
+    return;
+  }
+  PrimitiveComponent->WakeRigidBody(NAME_None);
   FTransform Transf = OwnerVehicle->GetActorTransform();
   const FVector LocVel = Transf.TransformVector(TargetVelocity);
   PrimitiveComponent->SetPhysicsLinearVelocity(LocVel, false, "None");


### PR DESCRIPTION
# Summary
**Acceleration input is now supported for CARLA vehicles.**
Autoware supports acceleration input, making it ideal for controlling vehicles. This implementation is based on interviews with Autoware developers. Additionally, it does not affect existing implementations such as Ackerman control or Velocity control.

- after 
  
    https://github.com/user-attachments/assets/ff1a106f-f897-423f-8cbe-970a0d6bc85e

  <img width="1220" height="897" alt="after" src="https://github.com/user-attachments/assets/3938b2a7-bcaf-48d8-a4ef-bcec0c9f4b27" />

  - The sluggishness of unintended movements during acceleration and deceleration has been resolved, and Autoware can now come to a stop just before the stop line. (see `carla_autoware_after.mp4`)
  - Input support based on acceleration (m/s²)
  - Eliminating unintended time lag between control input and output (see `after.png`)
  - Improving steering input and output consistency
  - Ensure consistency from ROS2 to CARLA vehicle input. Operation tested using the `/control/command/control_cmd` ros2 topic.

- before

  https://github.com/user-attachments/assets/30762cc7-2288-42f5-825a-c93c70d7f4fb

  <img width="1220" height="897" alt="before" src="https://github.com/user-attachments/assets/d45a617e-b515-4744-b203-137cc9f12494" />

  - Due to a delay in converting input (speed, acceleration) to pedal position (0–1), Autoware cannot stop just before the stop line. (see `carla_autoware_before.mp4`)
  - speed (m/s) and acceleration (m/s^2) -> pedal (0 - 1) conversion with PID input
  - A 3-4 second time lag from input to output (due to unintended internal unit conversion) (see `before.png`)
  - Steering input and output mismatch. The more you turn the wheel, the more it drifts (see `before.png`).
  - ROS2 -> CARLA Vehicle Input Alignment Discrepancy


The current status is that we have acquired a mechanism supporting acceleration input and capable of generating outputs matching acceleration and steering inputs. Going forward, we will build more analytical and superior models through interviews with Autoware developers. (For example, by limiting rate of change and reproducing input delays.)

# Test

- Real-time plot showing the degree of alignment between acceleration and steering input/output

  https://github.com/user-attachments/assets/4a31063e-f5e3-40c5-a27a-ecd983be77bd

- `/control/command/control_cmd` Drive the vehicle via ROS2 topics

  https://github.com/user-attachments/assets/b0a5ca9c-b5bd-44c9-acfb-f6579e82ad12

- Autonomous driving with Autoware

  https://github.com/user-attachments/assets/40388b02-4e8c-4da6-8854-6a2c42ebba5f

  https://github.com/user-attachments/assets/b41b5911-33b1-4e80-9064-19c014140b96

# Future planned implementations

The following items have been compiled based entirely on interviews with Autoware developers.

- Add a rate-of-change limit to steering and acceleration inputs
- Enable setting a first-order delay for steering input and acceleration input
- In addition, vehicle visuals such as control mode switching, gear shifting, and lights, etc.