### PR TITLE
Pre-merge A: Apply all upstream Actor.cpp changes

### DIFF
--- a/PythonAPI/carla/src/Actor.cpp
+++ b/PythonAPI/carla/src/Actor.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Computer Vision Center (CVC) at the Universitat Autonoma
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
 // de Barcelona (UAB).
 //
 // This work is licensed under the terms of the MIT license.
@@ -32,9 +32,18 @@ static void AddActorImpulse(cc::Actor &self,
   self.AddImpulse(impulse);
 }
 
+static void AddActorImpulseAtLocation(carla::client::Actor &self,
+    const carla::geom::Vector3D &impulse, const carla::geom::Location &location) {
+  self.AddImpulse(impulse, location);
+}
 static void AddActorForce(cc::Actor &self,
     const cg::Vector3D &force) {
   self.AddForce(force);
+}
+
+static void AddActorForceAtLocation(carla::client::Actor &self,
+  const carla::geom::Vector3D &force, const carla::geom::Location &location) {
+self.AddForce(force, location);
 }
 
 static auto GetGroupTrafficLights(cc::TrafficLight &self) {
@@ -119,10 +128,10 @@ void export_actor() {
       .def("set_target_angular_velocity", &cc::Actor::SetTargetAngularVelocity, (arg("angular_velocity")))
       .def("enable_constant_velocity", &cc::Actor::EnableConstantVelocity, (arg("velocity")))
       .def("disable_constant_velocity", &cc::Actor::DisableConstantVelocity)
-      .def("enable_constant_acceleration", &cc::Actor::EnableConstantAcceleration, (arg("acceleration")))
-      .def("disable_constant_acceleration", &cc::Actor::DisableConstantAcceleration)
-      .def("add_impulse", &AddActorImpulse, (arg("impulse")))
+      .def("add_impulse", &AddActorImpulse, (arg("impulse"))) 
+      .def("add_impulse_at_location", &AddActorImpulseAtLocation, (arg("impulse"), arg("location")))
       .def("add_force", &AddActorForce, (arg("force")))
+      .def("add_force_at_location", &AddActorForceAtLocation, (arg("force"), arg("location")))
       .def("add_angular_impulse", &cc::Actor::AddAngularImpulse, (arg("angular_impulse")))
       .def("add_torque", &cc::Actor::AddTorque, (arg("torque")))
       .def("set_simulate_physics", &cc::Actor::SetSimulatePhysics, (arg("enabled") = true))


### PR DESCRIPTION
<!--
Checklist:
  - [x] Your branch is up-to-date with the `ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes
-->

#### Description

Pre-apply all upstream `ue5-dev` changes to `PythonAPI/carla/src/Actor.cpp` to enable a zero-conflict upstream merge.

Changes applied from upstream:
- Update copyright year from 2024 to 2026
- Add `AddActorImpulseAtLocation` and `AddActorForceAtLocation` helper functions
- Add `add_impulse_at_location` and `add_force_at_location` Python bindings
- Remove `enable_constant_acceleration` / `disable_constant_acceleration` bindings (temporarily — restored in a post-merge patch)

This patch makes `Actor.cpp` identical to the upstream version so that merging `ue5-dev` produces no diff for this file. The autoware-specific acceleration bindings are restored in a separate post-merge patch.

This is part of a 4-patch series (A–D) to prepare for upstream ue5-dev merge with zero manual conflict resolution.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04 (Linux)
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 5.5 (CarlaUnreal fork)

#### Possible Drawbacks

`enable_constant_acceleration` / `disable_constant_acceleration` Python API is temporarily unavailable between this patch and the post-merge restoration patch. This is by design to avoid merge conflicts with upstream.