### PR TITLE
Fix: Add null check for MgrsDataAsset in AutowareGnssSensor

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Autoware/Sensors/AutowareGnssSensor.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Autoware/Sensors/AutowareGnssSensor.cpp
@@ -75,11 +75,13 @@ void AAutowareGnssSensor::PostPhysTick(UWorld* World, ELevelTick TickType, float
 		auto StreamId = carla::streaming::detail::token_type(GetToken()).get_stream_id();
 		AActor* ParentActor = GetAttachParentActor();
 		const FTransform sensor_world_transform = GetActorTransform();
-		double mgrs_offset_position[3] = {
-			static_cast<double>(MgrsDataAsset->MgrsOffsetPosition.X),
-			static_cast<double>(MgrsDataAsset->MgrsOffsetPosition.Y),
-			static_cast<double>(MgrsDataAsset->MgrsOffsetPosition.Z),
-		};
+		double mgrs_offset_position[3] = {0.0, 0.0, 0.0};
+		if (MgrsDataAsset)
+		{
+			mgrs_offset_position[0] = static_cast<double>(MgrsDataAsset->MgrsOffsetPosition.X);
+			mgrs_offset_position[1] = static_cast<double>(MgrsDataAsset->MgrsOffsetPosition.Y);
+			mgrs_offset_position[2] = static_cast<double>(MgrsDataAsset->MgrsOffsetPosition.Z);
+		}
 		
 		if (ParentActor)
 		{


### PR DESCRIPTION
<!--
Checklist:
  - [x] Your branch is up-to-date with the `ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes
-->

#### Description

Add null guard for `MgrsDataAsset` in `AAutowareGnssSensor::PostPhysTick()` to prevent SIGSEGV (Signal 11) when MGRS data asset is not configured for the current map.

**Root cause:** `MgrsDataAsset->MgrsOffsetPosition` was dereferenced unconditionally inside the `#if defined(WITH_ROS2)` block at line 79. When `LoadMgrsData()` fails to load the asset (e.g., the current map has no MGRS data asset configured in `AutowareWorldSettings`), `MgrsDataAsset` remains `nullptr` and the dereference causes a segfault at address `0x48`.

**Fix:** Initialize `mgrs_offset_position` to `{0.0, 0.0, 0.0}` and only populate from `MgrsDataAsset` if non-null. This allows `AutowareGnssSensor` to function on maps without MGRS data (e.g., Town10HD_Opt) by publishing with zero MGRS offset.

**Bug introduced in:** `8791ce07b` (2025-11-26). The original `ComputeGeoLocation()` had a proper null check with `Super::ComputeGeoLocation()` fallback, but the rewrite to direct ROS2 publishing in `PostPhysTick()` omitted it.

**Crash evidence:** 7 identical crash reports in `~/.config/Epic/CarlaUnreal/Saved/Crashes/` (2026-03-09 to 2026-03-30), all at `AutowareGnssSensor.cpp:79`.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04 (Linux)
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 5.5 (CarlaUnreal fork)

#### Possible Drawbacks

When `MgrsDataAsset` is null, GNSS data is published with zero MGRS offset. Coordinates will not include MGRS correction on maps without the asset configured. This is preferable to crashing and matches the standard `AGnssSensor` behavior.