### PR TITLE
Fix: Correct NishishinjukuMap MapsToCook path in DefaultGame.ini

### DIFF
--- a/Unreal/CarlaUnreal/Config/DefaultGame.ini
+++ b/Unreal/CarlaUnreal/Config/DefaultGame.ini
@@ -49,7 +49,7 @@ bCookMapsOnly=False
 bTreatWarningsAsErrorsOnCook=False
 bSkipEditorContent=False
 +MapsToCook=(FilePath="/Game/Carla/Maps/Town10HD_Opt")
-+MapsToCook=(FilePath="/Game/Nishishinjuku/NishishinjukuMap")
++MapsToCook=(FilePath="/Game/Carla/Maps/NishishinjukuMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/OpenDriveMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/TestMaps/EmptyMap")
 +MapsToCook=(FilePath="/Game/Carla/Maps/Mine_01")


### PR DESCRIPTION
<!--
Checklist:
  - [x] Your branch is up-to-date with the `ue5-dev` branch and tested with latest changes
  - [ ] Extended the README / documentation, if necessary
  - [x] Code compiles correctly
  - [x] All tests passing with `make check` (only Linux)
  - [ ] If relevant, update CHANGELOG.md with your changes
-->

#### Description

Fix incorrect `MapsToCook` path for NishishinjukuMap in `DefaultGame.ini`.

The path was `/Game/Nishishinjuku/NishishinjukuMap` but the actual map asset is located at `/Game/Carla/Maps/NishishinjukuMap` (corresponding to `Content/Carla/Maps/NishishinjukuMap.umap`). The incorrect path caused UE5's cook process to silently skip the map, making it unavailable in packaged builds.

```diff
-+MapsToCook=(FilePath="/Game/Nishishinjuku/NishishinjukuMap")
++MapsToCook=(FilePath="/Game/Carla/Maps/NishishinjukuMap")
```

**Bug introduced in:** `73efc047b` (PR #32, 2026-01-16 — "Add Autoware support for Shinjuku level").

**Why it worked previously:** Developers had an uncommitted local change setting `GameDefaultMap` to `NishishinjukuMap` (correct path) in `DefaultEngine.ini`. UE5 automatically includes the default map in the cook regardless of `MapsToCook`, masking the incorrect path.

#### Where has this been tested?

  * **Platform(s):** Ubuntu 22.04 (Linux)
  * **Python version(s):** 3.10
  * **Unreal Engine version(s):** 5.5 (CarlaUnreal fork)

#### Possible Drawbacks

None. This is a pure path correction with no behavioral change.