### PR TITLE
sync: merge carla-simulator/carla@ue5-dev (replaces #51)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.8"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## LATEST Changes
 
+* Fixed Digital Twin Tool crashes on dense metropolitan OSM data, vegetation spawning inside driving lanes on rural maps, and one-way streets being silently excluded from generation (#9565, #9678)
 * Added Ubuntu 24.04 support alongside Ubuntu 22.04
 * Added NVIDIA RTX 50 series (Blackwell) support with driver 570+ and CDI-based Docker instructions
 * Fixed compiler warnings across 20 LibCarla files including signed/unsigned conversions, pessimizing moves, deep copies in range-for loops, and C-style casts (ported from ue4-dev)

--- a/Docs/start_introduction.md
+++ b/Docs/start_introduction.md
@@ -38,11 +38,11 @@ Welcome to CARLA.
 
 <div class="build-buttons">
 <p>
-<a href="../build_linux" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
+<a href="../build_linux_ue5" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
 <b>Linux</b> build</a>
 </p>
 <p>
-<a href="../build_windows" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
+<a href="../build_windows_ue5" target="_blank" class="btn btn-neutral" title="Go to the latest CARLA release">
 <b>Windows</b> build</a>
 </p>
 </div>

--- a/LibCarla/source/carla/road/Lane.cpp
+++ b/LibCarla/source/carla/road/Lane.cpp
@@ -204,7 +204,7 @@ namespace road {
   }
 
   std::pair<geom::Vector3D, geom::Vector3D> Lane::GetCornerPositions(
-      const double s, const float extra_width) const {
+      const double parameter_s, const float extra_width) const {
     const Road *road = GetRoad();
     DEBUG_ASSERT(road != nullptr);
 
@@ -217,6 +217,7 @@ namespace road {
     RELEASE_ASSERT(GetId() >= lanes.begin()->first);
     RELEASE_ASSERT(GetId() <= lanes.rbegin()->first);
 
+    const double s = geom::Math::Clamp(parameter_s, 0.0, road->GetLength());
     float lane_t_offset = 0.0f;
 
     if (GetId() < 0) {

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -1294,13 +1294,14 @@ namespace road {
             while(s_current < s_end){
               if(lane->GetWidth(s_current) != 0.0f){
                 const auto edges = lane->GetCornerPositions(s_current, 0);
-                if (edges.first == edges.second) continue;
-                geom::Vector3D director = edges.second - edges.first;
-                geom::Vector3D treeposition = edges.first - director.MakeUnitVector() * distancefromdrivinglineborder;
-                geom::Transform lanetransform = lane->ComputeTransform(s_current);
-                geom::Transform treeTransform(treeposition, lanetransform.rotation);
-                const carla::road::element::RoadInfoSpeed* roadinfo = lane->GetInfo<carla::road::element::RoadInfoSpeed>(s_current);
-                transforms.push_back(std::make_pair(treeTransform,roadinfo->GetType()));
+                if (edges.first != edges.second) {
+                  geom::Vector3D director = edges.second - edges.first;
+                  geom::Vector3D treeposition = edges.first - director.MakeUnitVector() * distancefromdrivinglineborder;
+                  geom::Transform lanetransform = lane->ComputeTransform(s_current);
+                  geom::Transform treeTransform(treeposition, lanetransform.rotation);
+                  const carla::road::element::RoadInfoSpeed* roadinfo = lane->GetInfo<carla::road::element::RoadInfoSpeed>(s_current);
+                  transforms.push_back(std::make_pair(treeTransform,roadinfo->GetType()));
+                }
               }
               s_current += distancebetweentrees;
             }

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -599,7 +599,20 @@ namespace road {
           successor.road_id != waypoint.road_id ||
           successor.section_id != waypoint.section_id ||
           successor.lane_id != waypoint.lane_id);
-      result = ConcatVectors(result, GetNext(successor, distance - remaining_lane_length));
+      // Fix situations, when next waypoint is in the opposite direction and
+      // this waypoint is his successor, so this function would end up in a loop
+      bool is_broken = false;
+      for (const auto &future_successor : GetSuccessors(successor)) {
+          if (future_successor.road_id == waypoint.road_id
+               && future_successor.lane_id == waypoint.lane_id
+               && future_successor.section_id == waypoint.section_id){
+            is_broken = true;
+            break;
+          }
+      }
+      if (!is_broken){
+        result = ConcatVectors(result, GetNext(successor, distance - remaining_lane_length));
+      }
     }
     return result;
   }
@@ -635,7 +648,20 @@ namespace road {
           successor.road_id != waypoint.road_id ||
           successor.section_id != waypoint.section_id ||
           successor.lane_id != waypoint.lane_id);
-      result = ConcatVectors(result, GetPrevious(successor, distance - remaining_lane_length));
+      // Fix situations, when next waypoint is in the opposite direction and
+      // this waypoint is his predecessor, so this function would end up in a loop
+      bool is_broken = false;
+      for (const auto &future_predecessor : GetPredecessors(successor)) {
+          if (future_predecessor.road_id == waypoint.road_id
+               && future_predecessor.lane_id == waypoint.lane_id
+               && future_predecessor.section_id == waypoint.section_id){
+            is_broken = true;
+            break;
+          }
+      }
+      if (!is_broken){
+        result = ConcatVectors(result, GetPrevious(successor, distance - remaining_lane_length));
+      }
     }
     return result;
   }
@@ -1268,6 +1294,7 @@ namespace road {
             while(s_current < s_end){
               if(lane->GetWidth(s_current) != 0.0f){
                 const auto edges = lane->GetCornerPositions(s_current, 0);
+                if (edges.first == edges.second) continue;
                 geom::Vector3D director = edges.second - edges.first;
                 geom::Vector3D treeposition = edges.first - director.MakeUnitVector() * distancefromdrivinglineborder;
                 geom::Transform lanetransform = lane->ComputeTransform(s_current);

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -22,6 +22,7 @@
 
 #include <third-party/marchingcube/MeshReconstruction.h>
 
+#include <limits>
 #include <vector>
 #include <unordered_map>
 #include <stdexcept>
@@ -38,6 +39,7 @@ namespace road {
   /// We use this epsilon to shift the waypoints away from the edges of the lane
   /// sections to avoid floating point precision errors.
   static constexpr double EPSILON = 10.0 * std::numeric_limits<double>::epsilon();
+  static constexpr double TREE_PLACEMENT_EPSILON = 1.0e-4;
 
   // ===========================================================================
   // -- Static local methods ---------------------------------------------------
@@ -1280,27 +1282,67 @@ namespace road {
       const auto& road = _data.GetRoads().at(id);
       if (!road.IsJunction()) {
         for (auto &&lane_section : road.GetLaneSections()) {
-          LaneId min_lane = 0;
+          LaneId min_lane = 0; // most negative (outermost right-side) driving lane
+          LaneId max_lane = 0; // most positive (outermost left-side) driving lane
           for (auto &pairlane : lane_section.GetLanes()) {
-            if (min_lane > pairlane.first && pairlane.second.GetType() == Lane::LaneType::Driving) {
-              min_lane = pairlane.first;
+            if (pairlane.second.GetType() == Lane::LaneType::Driving) {
+              if (pairlane.first < 0 && (min_lane == 0 || pairlane.first < min_lane)) {
+                min_lane = pairlane.first;
+              } else if (pairlane.first > 0 && pairlane.first > max_lane) {
+                max_lane = pairlane.first;
+              }
             }
           }
 
-          const road::Lane* lane = lane_section.GetLane(min_lane);
+          // Prefer the outermost right-side lane; fall back to the outermost
+          // left-side lane for one-way roads that only have positive-ID lanes.
+          // Skip if no driving lane is found on either side (avoids using the
+          // reference lane whose near-zero width places trees at road centre).
+          const LaneId outer_lane = (min_lane != 0) ? min_lane : max_lane;
+          if (outer_lane == 0) continue;
+
+          const road::Lane* lane = lane_section.GetLane(outer_lane);
           if( lane ) {
             double s_current = lane_section.GetDistance() + s_offset;
             const double s_end = lane_section.GetDistance() + lane_section.GetLength();
             while(s_current < s_end){
               if(lane->GetWidth(s_current) != 0.0f){
                 const auto edges = lane->GetCornerPositions(s_current, 0);
-                if (edges.first != edges.second) {
-                  geom::Vector3D director = edges.second - edges.first;
-                  geom::Vector3D treeposition = edges.first - director.MakeUnitVector() * distancefromdrivinglineborder;
-                  geom::Transform lanetransform = lane->ComputeTransform(s_current);
-                  geom::Transform treeTransform(treeposition, lanetransform.rotation);
-                  const carla::road::element::RoadInfoSpeed* roadinfo = lane->GetInfo<carla::road::element::RoadInfoSpeed>(s_current);
-                  transforms.push_back(std::make_pair(treeTransform,roadinfo->GetType()));
+                geom::Vector3D director = edges.second - edges.first;
+                // Use double precision for the length check to avoid false
+                // negatives from float cancellation on near-equal corners.
+                const double director_squared_length =
+                  static_cast<double>(director.x) * static_cast<double>(director.x) +
+                  static_cast<double>(director.y) * static_cast<double>(director.y) +
+                  static_cast<double>(director.z) * static_cast<double>(director.z);
+                // Skip degenerate or near-degenerate lane widths; normalising a
+                // near-zero vector produces unstable directions and can place
+                // trees on or very close to the road surface.
+                if (director_squared_length <= (TREE_PLACEMENT_EPSILON * TREE_PLACEMENT_EPSILON)) {
+                  s_current += distancebetweentrees;
+                  continue;
+                }
+                // GetCornerPositions returns the lane corners in (t_offset + width, t_offset - width) order.
+                // The true outer edge therefore depends on the lane side: for positive lane IDs it is the second corner,
+                // and for negative lane IDs it is the first. Offset farther outward so trees are always placed away from the driving surface.
+                const bool is_positive_lane = (lane->GetId() > 0);
+                const geom::Vector3D outer_corner =
+                  is_positive_lane ? edges.second : edges.first;
+                const geom::Vector3D inner_corner =
+                  is_positive_lane ? edges.first : edges.second;
+                const geom::Vector3D outward_direction =
+                    (outer_corner - inner_corner).MakeUnitVector();
+                geom::Vector3D treeposition =
+                    outer_corner + outward_direction * distancefromdrivinglineborder;
+                geom::Transform lanetransform = lane->ComputeTransform(s_current);
+                geom::Transform treeTransform(treeposition, lanetransform.rotation);
+                const carla::road::element::RoadInfoSpeed* roadinfo = lane->GetInfo<carla::road::element::RoadInfoSpeed>(s_current);
+                // roadinfo is null for roads without an explicit maxspeed OSM tag
+                // (common in urban areas that rely on default speed limits).
+                if (roadinfo) {
+                  transforms.push_back(std::make_pair(treeTransform, roadinfo->GetType()));
+                } else {
+                  transforms.push_back(std::make_pair(treeTransform, "Town"));
                 }
               }
               s_current += distancebetweentrees;
@@ -1495,6 +1537,22 @@ namespace road {
     for( auto& road : _data.GetRoads() ){
       auto &&lane_section = (*road.second.GetLaneSections().begin());
       const road::Lane* lane = road.second.IsRHT() ? lane_section.GetLane(-1) : lane_section.GetLane(1);
+      if (!lane) {
+        // Fallback: the expected innermost lane (−1 for RHT, +1 for LHT) is
+        // absent (common on one-way streets and complex urban junctions).
+        // Pick the driving lane closest to the reference line (smallest abs id)
+        // to minimise the position error used for bounding-box filtering.
+        int best_abs_id = std::numeric_limits<int>::max();
+        for (const auto& pairlane : lane_section.GetLanes()) {
+          if (pairlane.first != 0 && pairlane.second.GetType() == Lane::LaneType::Driving) {
+            const int abs_id = std::abs(pairlane.first);
+            if (abs_id < best_abs_id) {
+              best_abs_id = abs_id;
+              lane = &pairlane.second;
+            }
+          }
+        }
+      }
       if( lane ) {
         const double s_check = lane_section.GetDistance() + lane_section.GetLength() * 0.5;
         geom::Location roadLocation = lane->ComputeTransform(s_check).location;

--- a/LibCarla/source/carla/road/Map.cpp
+++ b/LibCarla/source/carla/road/Map.cpp
@@ -599,8 +599,8 @@ namespace road {
           successor.road_id != waypoint.road_id ||
           successor.section_id != waypoint.section_id ||
           successor.lane_id != waypoint.lane_id);
-      // Fix situations, when next waypoint is in the opposite direction and
-      // this waypoint is his successor, so this function would end up in a loop
+      // Fix situations where the next waypoint is in the opposite direction and
+      // this waypoint is its successor, so this function would end up in a loop
       bool is_broken = false;
       for (const auto &future_successor : GetSuccessors(successor)) {
           if (future_successor.road_id == waypoint.road_id

--- a/LibCarla/source/carla/road/MeshFactory.cpp
+++ b/LibCarla/source/carla/road/MeshFactory.cpp
@@ -761,7 +761,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
             size_t currentIndex = out_mesh.GetVertices().size() + 1;
 
             std::pair<geom::Vector3D, geom::Vector3D> edges =
-              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
+              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width, 0.0f);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(edges.second);
@@ -781,7 +781,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
             size_t currentIndex = out_mesh.GetVertices().size() + 1;
 
             std::pair<geom::Vector3D, geom::Vector3D> edges =
-              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
+              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width, road_param.extra_lane_width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(edges.second);
@@ -792,7 +792,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
               s_current = s_end;
             }
 
-            edges = ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
+            edges = ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width, road_param.extra_lane_width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(edges.second);
@@ -855,7 +855,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
         carla::road::element::LaneMarking lane_mark_info(*road_info_mark);
 
         std::pair<geom::Vector3D, geom::Vector3D> edges =
-              ComputeEdgesForLanemark(lane_section, lane, s_end, lane_mark_info.width);
+              ComputeEdgesForLanemark(lane_section, lane, s_end, lane_mark_info.width, 0.0f);
 
         out_mesh.AddVertex(edges.first);
         out_mesh.AddVertex(edges.second);
@@ -916,7 +916,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
             size_t currentIndex = out_mesh.GetVertices().size() + 1;
 
             std::pair<geom::Vector3D, geom::Vector3D> edges =
-              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
+              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width, road_param.extra_lane_width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(edges.second);
@@ -926,7 +926,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
               s_current = s_end;
             }
 
-            edges = ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
+            edges = ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width, road_param.extra_lane_width);
 
             out_mesh.AddVertex(edges.first);
             out_mesh.AddVertex(edges.second);
@@ -1135,9 +1135,10 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
       const road::LaneSection& lane_section,
       const road::Lane& lane,
       const double s_current,
-      const double lanemark_width) const {
+      const double lanemark_width,
+      const float extra_width) const {
     std::pair<geom::Vector3D, geom::Vector3D> edges =
-      lane.GetCornerPositions(s_current, road_param.extra_lane_width);
+      lane.GetCornerPositions(s_current, extra_width);
 
     geom::Vector3D director;
     if (edges.first != edges.second) {
@@ -1147,7 +1148,7 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
       const std::map<road::LaneId, road::Lane> & lanes = lane_section.GetLanes();
       for (const auto& lane_pair : lanes) {
         std::pair<geom::Vector3D, geom::Vector3D> another_edge =
-          lane_pair.second.GetCornerPositions(s_current, road_param.extra_lane_width);
+          lane_pair.second.GetCornerPositions(s_current, extra_width);
         if (another_edge.first != another_edge.second) {
           director = another_edge.second - another_edge.first;
           director /= director.Length();

--- a/LibCarla/source/carla/road/MeshFactory.cpp
+++ b/LibCarla/source/carla/road/MeshFactory.cpp
@@ -760,14 +760,11 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
           case carla::road::element::LaneMarking::Type::Solid: {
             size_t currentIndex = out_mesh.GetVertices().size() + 1;
 
-            std::pair<geom::Vector3D, geom::Vector3D> edges = lane.GetCornerPositions(s_current, 0);
-
-            geom::Vector3D director = edges.second - edges.first;
-            director /= director.Length();
-            geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
+            std::pair<geom::Vector3D, geom::Vector3D> edges =
+              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
-            out_mesh.AddVertex(endmarking);
+            out_mesh.AddVertex(edges.second);
 
             out_mesh.AddIndex(currentIndex);
             out_mesh.AddIndex(currentIndex + 1);
@@ -784,28 +781,21 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
             size_t currentIndex = out_mesh.GetVertices().size() + 1;
 
             std::pair<geom::Vector3D, geom::Vector3D> edges =
-              lane.GetCornerPositions(s_current, road_param.extra_lane_width);
-
-            geom::Vector3D director = edges.second - edges.first;
-            director /= director.Length();
-            geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
+              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
-            out_mesh.AddVertex(endmarking);
+            out_mesh.AddVertex(edges.second);
 
             s_current += road_param.resolution * 3;
             if (s_current > s_end)
             {
               s_current = s_end;
             }
-            edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
 
-            director = edges.second - edges.first;
-            director /= director.Length();
-            endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
+            edges = ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
-            out_mesh.AddVertex(endmarking);
+            out_mesh.AddVertex(edges.second);
 
             out_mesh.AddIndex(currentIndex);
             out_mesh.AddIndex(currentIndex + 1);
@@ -863,13 +853,12 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
       const carla::road::element::RoadInfoMarkRecord* road_info_mark = lane.GetInfo<carla::road::element::RoadInfoMarkRecord>(s_current);
       if (road_info_mark != nullptr) {
         carla::road::element::LaneMarking lane_mark_info(*road_info_mark);
-        std::pair<geom::Vector3D, geom::Vector3D> edges = lane.GetCornerPositions(s_end, 0);
-        geom::Vector3D director = edges.second - edges.first;
-        director /= director.Length();
-        geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
+
+        std::pair<geom::Vector3D, geom::Vector3D> edges =
+              ComputeEdgesForLanemark(lane_section, lane, s_end, lane_mark_info.width);
 
         out_mesh.AddVertex(edges.first);
-        out_mesh.AddVertex(endmarking);
+        out_mesh.AddVertex(edges.second);
       }
       inout.push_back(std::make_unique<Mesh>(out_mesh));
     }
@@ -927,28 +916,20 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
             size_t currentIndex = out_mesh.GetVertices().size() + 1;
 
             std::pair<geom::Vector3D, geom::Vector3D> edges =
-              lane.GetCornerPositions(s_current, road_param.extra_lane_width);
-
-            geom::Vector3D director = edges.second - edges.first;
-            director /= director.Length();
-            geom::Vector3D endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
+              ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
-            out_mesh.AddVertex(endmarking);
+            out_mesh.AddVertex(edges.second);
 
             s_current += road_param.resolution * 3;
             if (s_current > s_end) {
               s_current = s_end;
             }
 
-            edges = lane.GetCornerPositions(s_current, road_param.extra_lane_width);
-
-            director = edges.second - edges.first;
-            director /= director.Length();
-            endmarking = edges.first + director * static_cast<float>(lane_mark_info.width);
+            edges = ComputeEdgesForLanemark(lane_section, lane, s_current, lane_mark_info.width);
 
             out_mesh.AddVertex(edges.first);
-            out_mesh.AddVertex(endmarking);
+            out_mesh.AddVertex(edges.second);
 
             out_mesh.AddIndex(currentIndex);
             out_mesh.AddIndex(currentIndex + 1);
@@ -1149,6 +1130,34 @@ std::map<road::Lane::LaneType , std::vector<std::unique_ptr<Mesh>>> MeshFactory:
     return std::make_unique<Mesh>(out_mesh);
   }
 
+
+  std::pair<geom::Vector3D, geom::Vector3D> MeshFactory::ComputeEdgesForLanemark(
+      const road::LaneSection& lane_section,
+      const road::Lane& lane,
+      const double s_current,
+      const double lanemark_width) const {
+    std::pair<geom::Vector3D, geom::Vector3D> edges =
+      lane.GetCornerPositions(s_current, road_param.extra_lane_width);
+
+    geom::Vector3D director;
+    if (edges.first != edges.second) {
+      director = edges.second - edges.first;
+      director /= director.Length();
+    } else {
+      const std::map<road::LaneId, road::Lane> & lanes = lane_section.GetLanes();
+      for (const auto& lane_pair : lanes) {
+        std::pair<geom::Vector3D, geom::Vector3D> another_edge =
+          lane_pair.second.GetCornerPositions(s_current, road_param.extra_lane_width);
+        if (another_edge.first != another_edge.second) {
+          director = another_edge.second - another_edge.first;
+          director /= director.Length();
+          break;
+        }
+      }
+    }
+    geom::Vector3D endmarking = edges.first + director * static_cast<float>(lanemark_width);
+    return std::make_pair(edges.first, endmarking);
+  }
 
 } // namespace geom
 } // namespace carla

--- a/LibCarla/source/carla/road/MeshFactory.h
+++ b/LibCarla/source/carla/road/MeshFactory.h
@@ -148,6 +148,15 @@ namespace geom {
 
     RoadParameters road_param;
 
+  private:
+
+    // Calculate the points on both sides of the lane mark for the specified s_current
+    std::pair<geom::Vector3D, geom::Vector3D> ComputeEdgesForLanemark(
+      const road::LaneSection& lane_section,
+      const road::Lane& lane,
+      const double s_current,
+      const double lanemark_width) const;
+
   };
 
 } // namespace geom

--- a/LibCarla/source/carla/road/MeshFactory.h
+++ b/LibCarla/source/carla/road/MeshFactory.h
@@ -155,7 +155,8 @@ namespace geom {
       const road::LaneSection& lane_section,
       const road::Lane& lane,
       const double s_current,
-      const double lanemark_width) const;
+      const double lanemark_width,
+      const float extra_width) const;
 
   };
 

--- a/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
+++ b/LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp
@@ -489,10 +489,10 @@ namespace ros2 {
     descriptor3.datatype(sensor_msgs::msg::PointField__FLOAT64);
     descriptor3.count(1);
     sensor_msgs::msg::PointField descriptor4;
-    descriptor3.name("pol");
-    descriptor3.offset(12);
-    descriptor3.datatype(sensor_msgs::msg::PointField__INT8);
-    descriptor3.count(1);
+    descriptor4.name("pol");
+    descriptor4.offset(12);
+    descriptor4.datatype(sensor_msgs::msg::PointField__INT8);
+    descriptor4.count(1);
 
     const size_t point_size = sizeof(carla::sensor::data::DVSEvent);
     _point_cloud->_pc.width(width);

--- a/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
+++ b/LibCarla/source/carla/trafficmanager/LocalizationStage.cpp
@@ -341,6 +341,9 @@ SimpleWaypointPtr LocalizationStage::AssignLaneChange(const ActorId actor_id,
   SimpleWaypointPtr change_over_point = nullptr;
 
   // Retrieve waypoint buffer for current vehicle.
+  if (buffer_map.find(actor_id) == buffer_map.end()) {
+    return change_over_point;
+  }
   const Buffer &waypoint_buffer = buffer_map.at(actor_id);
 
   // Check buffer is not empty.
@@ -592,6 +595,9 @@ void LocalizationStage::ImportRoute(Route &imported_actions, Buffer &waypoint_bu
 }
 
 Action LocalizationStage::ComputeNextAction(const ActorId& actor_id) {
+  if (buffer_map.find(actor_id) == buffer_map.end()) {
+    return std::make_pair(RoadOption::Void, nullptr);
+  }
   auto waypoint_buffer = buffer_map.at(actor_id);
   auto next_action = std::make_pair(RoadOption::LaneFollow, waypoint_buffer.back()->GetWaypoint());
   bool is_lane_change = false;
@@ -626,8 +632,11 @@ Action LocalizationStage::ComputeNextAction(const ActorId& actor_id) {
 
 ActionBuffer LocalizationStage::ComputeActionBuffer(const ActorId& actor_id) {
 
-  auto waypoint_buffer = buffer_map.at(actor_id);
   ActionBuffer action_buffer;
+  if (buffer_map.find(actor_id) == buffer_map.end()) {
+    return action_buffer;
+  }
+  auto waypoint_buffer = buffer_map.at(actor_id);
   Action lane_change;
   bool is_lane_change = false;
   SimpleWaypointPtr buffer_front = waypoint_buffer.front();

--- a/LibCarla/source/test/client/test_road_regression_9565.cpp
+++ b/LibCarla/source/test/client/test_road_regression_9565.cpp
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+// Regression tests for carla-simulator/carla#9565
+// Digital Twin Tool: crash on metropolitan OSM data, trees on roads,
+// and one-way streets excluded from generation.
+
+#include "test.h"
+
+#include <carla/geom/Vector3D.h>
+#include <carla/opendrive/OpenDriveParser.h>
+#include <carla/road/Map.h>
+
+#include <cmath>
+#include <string>
+#include <utility>
+#include <vector>
+
+
+using namespace carla::opendrive;
+using namespace carla::geom;
+
+constexpr float TREE_Y_TOLERANCE = 0.01f;
+
+// --- minimal OpenDRIVE helpers -----------------------------------------------
+
+static std::string MakeHeader() {
+  return R"(<?xml version="1.0" encoding="UTF-8"?>
+<OpenDRIVE>
+  <header revMajor="1" revMinor="4" name="" version="1"
+          north="100" south="-100" east="100" west="-100"/>
+)";
+}
+
+// Straight road running along X axis from (x0,0) to (x0+length,0).
+// lane_xml should be the full <lanes>...</lanes> block.
+static std::string MakeRoad(
+    int id, float x0, float length,
+    const std::string& lane_xml,
+    bool with_speed = true) {
+  std::string speed_block = with_speed
+      ? R"(<type s="0" type="town"><speed max="50" unit="km/h"/></type>)"
+      : "";
+  return
+    "  <road name=\"R" + std::to_string(id) + "\" length=\"" + std::to_string(length) +
+    "\" id=\"" + std::to_string(id) + "\" junction=\"-1\">\n" +
+    "    " + speed_block + "\n" +
+    "    <planView><geometry s=\"0\" x=\"" + std::to_string(x0) +
+    "\" y=\"0\" hdg=\"0\" length=\"" + std::to_string(length) + "\"><line/></geometry></planView>\n" +
+    "    <elevationProfile><elevation s=\"0\" a=\"0\" b=\"0\" c=\"0\" d=\"0\"/></elevationProfile>\n" +
+    "    <lateralProfile/>\n" +
+    lane_xml + "\n" +
+    "  </road>\n";
+}
+
+// Bidirectional road: lane -1 (right driving) + lane +1 (left driving).
+static std::string BidirectionalLanes() {
+  return R"(
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>)";
+}
+
+// One-way road with ONLY positive lanes --no lane -1.
+// This road was silently excluded by FilterRoadsByPosition before the fix.
+static std::string PositiveOnlyLanes() {
+  return R"(
+    <lanes>
+      <laneSection s="0">
+        <left>
+          <lane id="1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+          <lane id="2" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </left>
+        <center><lane id="0" type="none" level="false"/></center>
+      </laneSection>
+    </lanes>)";
+}
+
+// One-way road with ONLY negative lanes (normal right-side traffic).
+static std::string NegativeOnlyLanes() {
+  return R"(
+    <lanes>
+      <laneSection s="0">
+        <center><lane id="0" type="none" level="false"/></center>
+        <right>
+          <lane id="-1" type="driving" level="false">
+            <width sOffset="0" a="3.5" b="0" c="0" d="0"/>
+          </lane>
+        </right>
+      </laneSection>
+    </lanes>)";
+}
+
+// --- Bug 3: FilterRoadsByPosition includes one-way positive-lane roads -------
+//
+// Before fix: only queried lane -1; roads without it were silently excluded.
+// After fix:  falls back to the driving lane with smallest abs(id).
+// -----------------------------------------------------------------------------
+TEST(road, filter_roads_includes_positive_only_lanes_9565) {
+  // Three roads side-by-side along X axis, all centred around Y=0.
+  //   Road 0 (x=0..50):  bidirectional   -- has lane -1, was always included
+  //   Road 1 (x=60..110): positive-only  -- no lane -1, was EXCLUDED before fix
+  //   Road 2 (x=120..170): negative-only -- has lane -1, was always included
+  std::string xodr = MakeHeader()
+      + MakeRoad(0, 0.f,   50.f, BidirectionalLanes())
+      + MakeRoad(1, 60.f,  50.f, PositiveOnlyLanes())
+      + MakeRoad(2, 120.f, 50.f, NegativeOnlyLanes())
+      + "</OpenDRIVE>\n";
+
+  auto map = OpenDriveParser::Load(xodr);
+  ASSERT_TRUE(map.has_value());
+
+  // Bounding box covering all three roads.
+  // FilterRoadsByPosition checks minpos.y > y > maxpos.y (Y axis is inverted),
+  // so minpos.y must be the larger (positive) value.
+  const Vector3D minpos(-10.f,  20.f, -10.f);
+  const Vector3D maxpos(200.f, -20.f,  10.f);
+
+  auto included = map->GetMap().FilterRoadsByPosition(minpos, maxpos);
+
+  // All three roads must be included after the fix.
+  EXPECT_EQ(included.size(), 3u)
+      << "FilterRoadsByPosition excluded a road with positive-only lanes";
+}
+
+// --- Bug 1 + Bug 2: GetTreesTransform robustness -----------------------------
+//
+// Bug 1: roadinfo==nullptr (no maxspeed tag) caused SIGSEGV.
+// Bug 2: min_lane==0 / degenerate corners placed trees on the road surface.
+// -----------------------------------------------------------------------------
+TEST(road, get_trees_transform_no_crash_without_speed_9565) {
+  // Road without any <speed> element --roadinfo will be nullptr.
+  std::string xodr = MakeHeader()
+      + MakeRoad(0, 0.f, 100.f, BidirectionalLanes(), /*with_speed=*/false)
+      + "</OpenDRIVE>\n";
+
+  auto map = OpenDriveParser::Load(xodr);
+  ASSERT_TRUE(map.has_value());
+
+  // FilterRoadsByPosition checks minpos.y > y > maxpos.y (Y axis inverted).
+  const Vector3D minpos(-10.f,  20.f, -10.f);
+  const Vector3D maxpos(110.f, -20.f,  10.f);
+
+  // Must not crash (a regression to the null dereference will fail by crashing).
+  std::vector<std::pair<carla::geom::Transform, std::string>> result =
+      map->GetMap().GetTreesTransform(minpos, maxpos, 10.f, 2.f);
+
+  // Must produce at least one tree so the fallback-type loop below is not vacuous.
+  ASSERT_GT(result.size(), 0u)
+      << "No trees generated for road without maxspeed tag";
+
+  // Fallback type "Town" must be used for all entries.
+  for (const auto& entry : result) {
+    EXPECT_EQ(entry.second, "Town")
+        << "Expected \"Town\" fallback for road without maxspeed tag";
+  }
+}
+
+TEST(road, get_trees_transform_positive_lane_road_gets_trees_9565) {
+  // One-way road with positive-only lanes: before the fix, min_lane stayed 0
+  // and the lane section was skipped --no trees were generated at all.
+  std::string xodr = MakeHeader()
+      + MakeRoad(0, 0.f, 100.f, PositiveOnlyLanes())
+      + "</OpenDRIVE>\n";
+
+  auto map = OpenDriveParser::Load(xodr);
+  ASSERT_TRUE(map.has_value());
+
+  // FilterRoadsByPosition checks minpos.y > y > maxpos.y (Y axis inverted).
+  const Vector3D minpos(-10.f,  20.f, -10.f);
+  const Vector3D maxpos(110.f, -20.f,  10.f);
+
+  auto result = map->GetMap().GetTreesTransform(minpos, maxpos, 10.f, 2.f);
+
+  ASSERT_GT(result.size(), 0u)
+      << "No trees generated for one-way road with positive-only lanes";
+
+  // PositiveOnlyLanes: lane id=1 (3.5m wide) and lane id=2 (3.5m wide).
+  // Outer edge of lane id=2 is at |Y| = 3.5 + 3.5 = 7.0m from road centre.
+  // distancefromdrivinglineborder=2.0 => trees placed 2.0m beyond that edge.
+  // Trees must satisfy |Y| >= 7.0 + 2.0 = 9.0.
+  const float lane1_width      = 3.5f;
+  const float lane2_width      = 3.5f;
+  const float dist_from_edge   = 2.0f;
+  const float outer_road_edge  = lane1_width + lane2_width;
+  const float min_expected_dist = outer_road_edge + dist_from_edge;  // 9.0
+  for (const auto& entry : result) {
+    const float tree_y = std::abs(entry.first.location.y);
+    EXPECT_NEAR(tree_y, min_expected_dist, TREE_Y_TOLERANCE)
+        << "Tree Y=" << entry.first.location.y
+        << " is not within ±" << TREE_Y_TOLERANCE << " of the expected minimum distance (|Y| = " << min_expected_dist << ")";
+  }
+}
+
+TEST(road, get_trees_transform_trees_outside_road_9565) {
+  // Verify trees are not placed inside the driving lane.
+  // Road: single right lane (id=-1, width=3.5m) centred at Y=0.
+  // Driving surface occupies Y in [-3.5, 0] (right side, post-Y-flip).
+  // DistanceFromRoadEdge=2.0 => trees should be at Y < -3.5 (beyond outer edge).
+  std::string xodr = MakeHeader()
+      + MakeRoad(0, 0.f, 100.f, NegativeOnlyLanes())
+      + "</OpenDRIVE>\n";
+
+  auto map = OpenDriveParser::Load(xodr);
+  ASSERT_TRUE(map.has_value());
+
+  // FilterRoadsByPosition checks minpos.y > y > maxpos.y (Y axis inverted).
+  const Vector3D minpos(-10.f,  20.f, -10.f);
+  const Vector3D maxpos(110.f, -20.f,  10.f);
+
+  auto result = map->GetMap().GetTreesTransform(minpos, maxpos, 10.f, 2.f);
+  ASSERT_GT(result.size(), 0u) << "No trees generated for negative-only lane road";
+
+  // Outer edge of lane -1 is at t=3.5m from road centre.
+  // distancefromdrivinglineborder=2.0 => trees placed 2.0m beyond that edge.
+  // After Y-flip, trees must be at |Y| >= 3.5 + 2.0 = 5.5.
+  const float lane_outer_edge   = 3.5f;
+  const float dist_from_edge    = 2.0f;
+  const float min_expected_dist = lane_outer_edge + dist_from_edge;
+
+  for (const auto& entry : result) {
+    const float tree_y = std::abs(entry.first.location.y);
+    EXPECT_NEAR(tree_y, min_expected_dist, TREE_Y_TOLERANCE)
+        << "Tree Y=" << entry.first.location.y
+        << " is not within ±" << TREE_Y_TOLERANCE << " of the expected minimum distance (|Y| = " << min_expected_dist << ")";
+  }
+}

--- a/LibCarla/source/test/common/test_pugixml.cpp
+++ b/LibCarla/source/test/common/test_pugixml.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Computer Vision Center (CVC) at the Universitat Autonoma
+// de Barcelona (UAB).
+//
+// This work is licensed under the terms of the MIT license.
+// For a copy, see <https://opensource.org/licenses/MIT>.
+
+#include "test.h"
+#include <pugixml/pugixml.hpp>
+
+using namespace pugi;
+
+TEST(pugixml, null_pointer_dereference_insert_move_before) {
+  // Create an empty node (without root, _root = nullptr)
+  xml_node empty_node;
+  ASSERT_FALSE(empty_node);
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child1 = root.append_child("child1");
+  xml_node child2 = root.append_child("child2");
+
+  // Attempt insert_move_before from an empty node
+  // Before the patch this would crash, now it should return an empty xml_node
+  xml_node result = empty_node.insert_move_before(child2, child1);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_move_after) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child1 = root.append_child("child1");
+  xml_node child2 = root.append_child("child2");
+
+  // Attempt insert_move_after from an empty node
+  xml_node result = empty_node.insert_move_after(child2, child1);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_child_before) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+
+  // Attempt insert_child_before from an empty node
+  xml_node result = empty_node.insert_child_before(node_element, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_child_after) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+
+  // Attempt insert_child_after from an empty node
+  xml_node result = empty_node.insert_child_after(node_element, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_copy_before) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+  xml_node proto = root.append_child("proto");
+
+  // Attempt insert_copy_before from an empty node
+  xml_node result = empty_node.insert_copy_before(proto, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}
+
+TEST(pugixml, null_pointer_dereference_insert_copy_after) {
+  // Create an empty node
+  xml_node empty_node;
+
+  // Create a valid document
+  xml_document doc;
+  xml_node root = doc.append_child("root");
+  xml_node child = root.append_child("child");
+  xml_node proto = root.append_child("proto");
+
+  // Attempt insert_copy_after from an empty node
+  xml_node result = empty_node.insert_copy_after(proto, child);
+
+  // Verify it returns an empty node without crashing
+  EXPECT_FALSE(result);
+}

--- a/LibCarla/source/third-party/pugixml/pugixml.cpp
+++ b/LibCarla/source/third-party/pugixml/pugixml.cpp
@@ -5826,7 +5826,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_child_before(xml_node_type type_, const xml_node& node)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -5844,7 +5844,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_child_after(xml_node_type type_, const xml_node& node)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -5933,7 +5933,7 @@ namespace pugi
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -5951,7 +5951,7 @@ namespace pugi
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
 		if (!alloc.reserve()) return xml_node();
@@ -6000,7 +6000,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_move_after(const xml_node& moved, const xml_node& node)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 		if (moved._root == node._root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);
@@ -6018,7 +6018,7 @@ namespace pugi
 	PUGI__FN xml_node xml_node::insert_move_before(const xml_node& moved, const xml_node& node)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
-		if (!node._root || node._root->parent != _root) return xml_node();
+		if (!_root || !node._root || node._root->parent != _root) return xml_node();
 		if (moved._root == node._root) return xml_node();
 
 		impl::xml_allocator& alloc = impl::get_allocator(_root);

--- a/PythonAPI/carla/src/TrafficManager.cpp
+++ b/PythonAPI/carla/src/TrafficManager.cpp
@@ -55,8 +55,10 @@ void InterSetImportedRoute(carla::traffic_manager::TrafficManager& self, const A
 boost::python::list InterGetNextAction(carla::traffic_manager::TrafficManager& self, const ActorPtr &actor_ptr) {
   boost::python::list l;
   auto next_action = self.GetNextAction(actor_ptr->GetId());
-  l.append(RoadOptionToString(next_action.first));
-  l.append(next_action.second);
+  if (next_action.second != nullptr) {
+    l.append(RoadOptionToString(next_action.first));
+    l.append(next_action.second);
+  }
   return l;
 }
 

--- a/PythonAPI/examples/manual_control.py
+++ b/PythonAPI/examples/manual_control.py
@@ -1201,6 +1201,8 @@ class CameraManager(object):
     def get_post_process_profile(self, map_name: str) -> str:
         if "Town10HD_Opt" in map_name:
             return "Town10HD_Opt"
+        if "Town_C" in map_name:
+            return "Town_C"
         return "Default"
 
     @staticmethod


### PR DESCRIPTION
## Summary

Syncs upstream [`carla-simulator/carla@ue5-dev`](https://github.com/carla-simulator/carla/tree/ue5-dev) into this fork's `main`. Supersedes #51 — GitHub's mergeability check reported CONFLICTING because it does not apply rename detection, but a local `git merge` resolves cleanly thanks to git's rename heuristic.

## Details

- PR #51 head (`carla-simulator/carla:ue5-dev`) is merged into `main` via a merge commit.
- The upstream change to `LibCarla/source/carla/ros2/publishers/CarlaDVSCameraPublisher.cpp` (descriptor3→descriptor4 name fix) is applied to this fork's renamed path `LibCarla/source/carla/ros2/dds/fastdds/publishers/CarlaDVSCameraPublisher.cpp`.
- The CycloneDDS mirror (`.../dds/cyclonedds/publishers/CarlaDVSCameraPublisher.cpp`) uses a different API and was not affected by the upstream bug.
- No other manual conflict resolution was required.

## Test plan

- [x] `./RglSetup.sh build` succeeds on top of the merge commit (exit 0).
- [ ] CI builds clean.
- [ ] Runtime smoke test in UE5 editor with RGL enabled.

## Follow-up

Close #51 once this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)