### PR TITLE
fix(server): correct ECarlaServerResponse enum typo breaking the build

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Server/CarlaServer.cpp
@@ -1312,7 +1312,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     {
       return RespondError(
           "set_actor_constant_acceleration_jerk_limit",
-          ECarlaServerResponse::FunctionNotAvailiableWhenDormant,
+          ECarlaServerResponse::FunctionNotAvailableWhenDormant,
           " Actor Id: " + FString::FromInt(ActorId));
     }
 
@@ -1345,7 +1345,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     {
       return RespondError(
           "set_actor_constant_acceleration_first_order_lag_tau",
-          ECarlaServerResponse::FunctionNotAvailiableWhenDormant,
+          ECarlaServerResponse::FunctionNotAvailableWhenDormant,
           " Actor Id: " + FString::FromInt(ActorId));
     }
 
@@ -2210,7 +2210,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     {
       return RespondError(
           "set_vehicle_steer_rate_limit",
-          ECarlaServerResponse::FunctionNotAvailiableWhenDormant,
+          ECarlaServerResponse::FunctionNotAvailableWhenDormant,
           " Actor Id: " + FString::FromInt(ActorId));
     }
 
@@ -2243,7 +2243,7 @@ BIND_SYNC(is_sensor_enabled_for_ros) << [this](carla::streaming::detail::stream_
     {
       return RespondError(
           "set_vehicle_steer_first_order_lag_tau",
-          ECarlaServerResponse::FunctionNotAvailiableWhenDormant,
+          ECarlaServerResponse::FunctionNotAvailableWhenDormant,
           " Actor Id: " + FString::FromInt(ActorId));
     }
 


### PR DESCRIPTION
## Summary
CarlaServer.cpp used ECarlaServerResponse::FunctionNotAvailiableWhenDormant (misspelled) in 4 places; the enum is FunctionNotAvailableWhenDormant (CarlaServerResponse.h). Fails to compile carla-unreal. Introduced in the vehicle-simulation merge (#55). Upstream ue5-dev uses the correct spelling.

## Test Plan
- [ ] carla-unreal-editor builds
- [ ] packaged build succeeds