### PR TITLE
feat(rgl): distance-based dynamic scene registration + multi-sensor

### DIFF
--- a/PythonAPI/examples/rgl_test_autoware_demo.py
+++ b/PythonAPI/examples/rgl_test_autoware_demo.py
@@ -855,14 +855,24 @@ def main():
 
 
     # Spawn Ego
-    try:
-        spawn_points = world.get_ego_spawn_points()
-    except AttributeError:
-        # Fallback when get_ego_spawn_points is not available (e.g. standard carla package)
-        spawn_points = world.get_map().get_spawn_points()
-    if not spawn_points:
-        raise RuntimeError("No spawn points available. Load a map that provides spawn points.")
-    spawn_point = random.choice(spawn_points)
+    _ego_spawn_env = os.environ.get("RGL_EGO_SPAWN")
+    if _ego_spawn_env:
+        # Fixed ego spawn for maps without spawn points (e.g. maps with no OpenDrive road network).
+        # Format: "x,y,z[,yaw]" in CARLA UE units (cm, deg).
+        _p = [float(v) for v in _ego_spawn_env.split(",")]
+        spawn_point = carla.Transform(
+            carla.Location(x=_p[0], y=_p[1], z=_p[2]),
+            carla.Rotation(yaw=_p[3] if len(_p) > 3 else 0.0))
+        log_info(f"Using fixed ego spawn from RGL_EGO_SPAWN: {spawn_point}")
+    else:
+        try:
+            spawn_points = world.get_ego_spawn_points()
+        except AttributeError:
+            # Fallback when get_ego_spawn_points is not available (e.g. standard carla package)
+            spawn_points = world.get_map().get_spawn_points()
+        if not spawn_points:
+            raise RuntimeError("No spawn points available. Load a map that provides spawn points.")
+        spawn_point = random.choice(spawn_points)
     ego = spawn_ego_with_sensors(world, spawn_point, args)
 
     world.tick()  # tick to process the changes (settings, ego + sensors spawn)

--- a/PythonAPI/examples/rgl_test_autoware_demo.py
+++ b/PythonAPI/examples/rgl_test_autoware_demo.py
@@ -234,6 +234,14 @@ def generate_vlp16_blueprint(blueprint_library, lidar_type="rgl",
         blueprint.set_attribute("lower_fov", "-20.0")
         blueprint.set_attribute("points_per_second", "288000")
 
+    # No-culling VRAM baseline: when RGL_NOCULL_RANGE_M is set, override the LiDAR
+    # range so the distance-culling sphere covers the whole map and every static
+    # mesh is registered. The point buffer is ray-count-based (range-independent),
+    # so VRAM stays comparable to the culled runs except for the registered scene.
+    _nocull_range = os.environ.get("RGL_NOCULL_RANGE_M")
+    if _nocull_range:
+        blueprint.set_attribute("range", _nocull_range)
+
     blueprint.set_attribute("sensor_tick", "0.1")
 
     # CARLA built-in ROS settings (used by enable_for_ros(), works for both ray_cast and rgl)

--- a/PythonAPI/rgl/tests/test_multisensor_culling.sh
+++ b/PythonAPI/rgl/tests/test_multisensor_culling.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# ============================================================================
+# Multi-sensor distance-culling regression test (automated)
+#
+# Launches the packaged CARLA server, then for each sensor config resets the
+# world (clean baseline), runs the RGL demo, and reads the server's
+# RGLSceneManager log. Verifies the union behavior: a spatially separated 2nd
+# sensor must register ADDITIONAL geometry (cachedMeshes rises vs single
+# sensor) — the regression the old first-tick-wins single-sensor design failed.
+#
+# Runs unattended. Requires GPU + package built with `package-development`.
+# Override any VAR=... at invocation, e.g.:
+#   SEP=250 DURATION=30 bash test_multisensor_culling.sh
+# ============================================================================
+set -u
+
+# ---- config (override via env) ----
+PKG_DIR="${PKG_DIR:-/mnt/dsk0/wk0/CARLA/T4Fork.RGL/CarlaUE5/Build/Package/Carla-0.10.0-Linux-Development/Linux}"
+DEMO="${DEMO:-/mnt/dsk0/wk0/CARLA/T4Fork.RGL/CarlaUE5/PythonAPI/examples/rgl_test_autoware_demo.py}"
+MAP="${MAP:-Town10HD_Opt}"
+PORT="${PORT:-2000}"
+DURATION="${DURATION:-25}"        # seconds each config runs before SIGINT
+SEP="${SEP:-150}"                 # meters between the 2 separated sensors (config c)
+RESET_WAIT="${RESET_WAIT:-9}"     # > SensorStaleTimeoutSeconds(5s): let registry clear
+SERVER_EXTRA="${SERVER_EXTRA:--RenderOffScreen -nosound -quality-level=Low}"
+LOG="${LOG:-/tmp/carla_server_$$.log}"
+RESULT="${RESULT:-/tmp/rgl_multisensor_result.txt}"
+
+SERVER_SH="$PKG_DIR/CarlaUnreal.sh"
+: > "$RESULT"
+log() { echo "[test] $*" | tee -a "$RESULT"; }
+
+cleanup() {
+    log "tearing down server group (pgid=$SERVER_PID)"
+    # CarlaUnreal.sh launches the real binary as a child; kill the whole group.
+    kill -INT  -- "-$SERVER_PID" 2>/dev/null
+    sleep 5
+    kill -9    -- "-$SERVER_PID" 2>/dev/null
+    # belt-and-suspenders: any CarlaUnreal binary still holding our port
+    pkill -9 -f "Binaries/Linux/CarlaUnreal .*carla-rpc-port=$PORT" 2>/dev/null
+    sleep 1
+}
+trap cleanup EXIT INT TERM
+
+# ---- 1. launch server in its own process group (setsid) ----
+[ -x "$SERVER_SH" ] || { log "ERROR: launcher not found/executable: $SERVER_SH"; exit 2; }
+log "launching CARLA: $MAP --ros2 -prefernvidia $SERVER_EXTRA -carla-rpc-port=$PORT"
+setsid "$SERVER_SH" "$MAP" --ros2 -prefernvidia $SERVER_EXTRA -carla-rpc-port="$PORT" > "$LOG" 2>&1 &
+SERVER_PID=$!   # session leader => PGID == SERVER_PID
+
+# ---- 2. wait for RPC port ----
+log "waiting for RPC port $PORT ..."
+ready=0
+for i in $(seq 1 90); do
+    if (echo > "/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then ready=1; break; fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then log "ERROR: server died early. tail:"; tail -20 "$LOG" | tee -a "$RESULT"; exit 3; fi
+    sleep 2
+done
+[ "$ready" = 1 ] || { log "ERROR: server not ready after ~180s. tail:"; tail -20 "$LOG" | tee -a "$RESULT"; exit 3; }
+log "server ready; warm-up 12s"
+sleep 12
+
+# ---- helpers ----
+# max integer value of a \K-anchored PCRE across a log window (from line $1)
+max_field() { tail -n +"$1" "$LOG" | grep -oP "$2" 2>/dev/null | sort -n | tail -1; }
+
+reset_world() {  # destroy lingering actors so each config starts from a clean registry
+    timeout 30 python3 - "$PORT" <<'PY' 2>/dev/null || true
+import sys, carla
+c = carla.Client('127.0.0.1', int(sys.argv[1])); c.set_timeout(20)
+w = c.get_world()
+for pat in ('sensor.*', 'vehicle.*', 'walker.*'):
+    for a in w.get_actors().filter(pat):
+        try: a.destroy()
+        except Exception: pass
+PY
+    sleep "$RESET_WAIT"   # let UnregisterSensor + stale-TTL clear the registry & static meshes
+}
+
+declare -A CACHED SENSORS VRAM
+run_config() {  # $1=name  rest=demo args
+    local name="$1"; shift
+    log "--- config '$name': reset + demo $* (${DURATION}s) ---"
+    reset_world
+    local before; before=$(( $(wc -l < "$LOG") + 1 ))
+    timeout --signal=INT "$DURATION" python3 "$DEMO" --carla_lidar_type rgl "$@" \
+        > "/tmp/demo_${name}.log" 2>&1 || true
+    sleep 3
+    VRAM[$name]=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')
+    SENSORS[$name]=$(max_field "$before" 'sensors=\s*\K[0-9]+')
+    # cachedMeshes appears in sync lines ("cachedMeshes= N") and the init scan ("Uploaded N unique meshes")
+    local m1 m2; m1=$(max_field "$before" 'cachedMeshes=\s*\K[0-9]+'); m2=$(max_field "$before" 'Uploaded\s+\K[0-9]+')
+    CACHED[$name]=$(printf '%s\n%s\n' "${m1:-0}" "${m2:-0}" | sort -n | tail -1)
+    log "  VRAM=${VRAM[$name]}MiB  maxSensors=${SENSORS[$name]:-?}  maxCachedMeshes=${CACHED[$name]:-?}"
+    log "  last sync: $(tail -n +"$before" "$LOG" | grep 'Dynamic sync active' | tail -1 | sed 's/.*RGLSceneManager/RGLSceneManager/')"
+}
+
+# ---- 3. run configs ----
+run_config a_single    --num_lidars 1
+run_config b_cluster   --num_lidars 4 --lidar_spawn_delta_x 2 --lidar_spawn_delta_y 2
+run_config c_separated --num_lidars 2 --lidar_spawn_delta_x "$SEP"
+
+# ---- 4. verdict ----
+log "============================================================"
+log "RESULT SUMMARY  (map=$MAP, sep=${SEP}m)"
+log "  (a) single    : maxSensors=${SENSORS[a_single]:-?}  maxCachedMeshes=${CACHED[a_single]:-?}  VRAM=${VRAM[a_single]:-?}MiB"
+log "  (b) cluster x4: maxSensors=${SENSORS[b_cluster]:-?}  maxCachedMeshes=${CACHED[b_cluster]:-?}  VRAM=${VRAM[b_cluster]:-?}MiB"
+log "  (c) separated : maxSensors=${SENSORS[c_separated]:-?}  maxCachedMeshes=${CACHED[c_separated]:-?}  VRAM=${VRAM[c_separated]:-?}MiB"
+log "------------------------------------------------------------"
+verdict=0
+a=${CACHED[a_single]:-0}; c=${CACHED[c_separated]:-0}
+sa=${SENSORS[a_single]:-0}; sc=${SENSORS[c_separated]:-0}
+[ "${a:-0}" -gt 0 ] || { log "FAIL: (a) produced no cachedMeshes reading"; verdict=1; }
+if [ "${sc:-0}" -gt "${sa:-0}" ]; then log "PASS: more sensors registered when separated (c=$sc > a=$sa)"; else log "FAIL: expected sensors(c) > sensors(a), got c=$sc a=$sa"; verdict=1; fi
+if [ "${c:-0}" -gt "${a:-0}" ]; then log "PASS: union registers more geometry for separated sensors (c=$c > a=$a)"; else log "FAIL: expected cachedMeshes(c) > cachedMeshes(a), got c=$c a=$a — if c≈a, increase SEP and re-run"; verdict=1; fi
+[ "$verdict" = 0 ] && log "OVERALL: PASS" || log "OVERALL: FAIL (full server log: $LOG)"
+log "============================================================"
+exit "$verdict"

--- a/PythonAPI/rgl/tests/test_multisensor_culling.sh
+++ b/PythonAPI/rgl/tests/test_multisensor_culling.sh
@@ -97,12 +97,16 @@ run_config() {  # $1=name  rest=demo args
 }
 
 # ---- 3. run configs ----
-# no-cull baseline: 1 sensor with a huge range -> registration sphere covers the
-# whole map -> every static mesh registered (= what we'd get without culling).
-DEMO_ENV="RGL_NOCULL_RANGE_M=$NOCULL_RANGE" run_config d_nocull --num_lidars 1
+# Culled configs first so their measurements are captured even if the no-cull
+# baseline below spikes VRAM / OOMs on a large map.
 run_config a_single    --num_lidars 1
 run_config b_cluster   --num_lidars 4 --lidar_spawn_delta_x 2 --lidar_spawn_delta_y 2
 run_config c_separated --num_lidars 2 --lidar_spawn_delta_x "$SEP"
+# no-cull baseline LAST: 1 sensor with a huge range -> registration sphere covers
+# the whole map -> every static mesh registered (= without culling). On a large map this
+# is the OOM scenario the feature prevents; if the server dies here, that crash is
+# itself the headline (culling avoids it) and the culled data above is preserved.
+DEMO_ENV="RGL_NOCULL_RANGE_M=$NOCULL_RANGE" run_config d_nocull --num_lidars 1
 
 # ---- 4. verdict ----
 nc=${CACHED[d_nocull]:-0}; ncv=${VRAM[d_nocull]:-0}

--- a/PythonAPI/rgl/tests/test_multisensor_culling.sh
+++ b/PythonAPI/rgl/tests/test_multisensor_culling.sh
@@ -21,6 +21,7 @@ MAP="${MAP:-Town10HD_Opt}"
 PORT="${PORT:-2000}"
 DURATION="${DURATION:-25}"        # seconds each config runs before SIGINT
 SEP="${SEP:-150}"                 # meters between the 2 separated sensors (config c)
+NOCULL_RANGE="${NOCULL_RANGE:-5000}"  # LiDAR range (m) for the no-culling baseline (covers whole map)
 RESET_WAIT="${RESET_WAIT:-9}"     # > SensorStaleTimeoutSeconds(5s): let registry clear
 SERVER_EXTRA="${SERVER_EXTRA:--RenderOffScreen -nosound -quality-level=Low}"
 LOG="${LOG:-/tmp/carla_server_$$.log}"
@@ -83,7 +84,7 @@ run_config() {  # $1=name  rest=demo args
     log "--- config '$name': reset + demo $* (${DURATION}s) ---"
     reset_world
     local before; before=$(( $(wc -l < "$LOG") + 1 ))
-    timeout --signal=INT "$DURATION" python3 "$DEMO" --carla_lidar_type rgl "$@" \
+    env ${DEMO_ENV:-} timeout --signal=INT "$DURATION" python3 "$DEMO" --carla_lidar_type rgl "$@" \
         > "/tmp/demo_${name}.log" 2>&1 || true
     sleep 3
     VRAM[$name]=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')
@@ -96,21 +97,39 @@ run_config() {  # $1=name  rest=demo args
 }
 
 # ---- 3. run configs ----
+# no-cull baseline: 1 sensor with a huge range -> registration sphere covers the
+# whole map -> every static mesh registered (= what we'd get without culling).
+DEMO_ENV="RGL_NOCULL_RANGE_M=$NOCULL_RANGE" run_config d_nocull --num_lidars 1
 run_config a_single    --num_lidars 1
 run_config b_cluster   --num_lidars 4 --lidar_spawn_delta_x 2 --lidar_spawn_delta_y 2
 run_config c_separated --num_lidars 2 --lidar_spawn_delta_x "$SEP"
 
 # ---- 4. verdict ----
+nc=${CACHED[d_nocull]:-0}; ncv=${VRAM[d_nocull]:-0}
+a=${CACHED[a_single]:-0};  av=${VRAM[a_single]:-0}
+c=${CACHED[c_separated]:-0}
+sa=${SENSORS[a_single]:-0}; sc=${SENSORS[c_separated]:-0}
+pct=$(awk "BEGIN{ if ($nc+0>0) printf \"%.0f\", 100*$a/$nc; else print 0 }")
+saved_m=$(( nc - a )); saved_v=$(( ncv - av ))
+
 log "============================================================"
-log "RESULT SUMMARY  (map=$MAP, sep=${SEP}m)"
+log "RESULT SUMMARY  (map=$MAP, sep=${SEP}m, nocull-range=${NOCULL_RANGE}m)"
+log "  (d) NO-CULL   : maxSensors=${SENSORS[d_nocull]:-?}  maxCachedMeshes=${CACHED[d_nocull]:-?}  VRAM=${VRAM[d_nocull]:-?}MiB  (whole map registered)"
 log "  (a) single    : maxSensors=${SENSORS[a_single]:-?}  maxCachedMeshes=${CACHED[a_single]:-?}  VRAM=${VRAM[a_single]:-?}MiB"
 log "  (b) cluster x4: maxSensors=${SENSORS[b_cluster]:-?}  maxCachedMeshes=${CACHED[b_cluster]:-?}  VRAM=${VRAM[b_cluster]:-?}MiB"
 log "  (c) separated : maxSensors=${SENSORS[c_separated]:-?}  maxCachedMeshes=${CACHED[c_separated]:-?}  VRAM=${VRAM[c_separated]:-?}MiB"
 log "------------------------------------------------------------"
+log "CULLING BENEFIT (registered mesh count = the RGL/OptiX VRAM driver):"
+log "  meshes : no-cull=$nc (whole map)  culled single=$a   -> culled keeps ${pct}%, ${saved_m} fewer meshes"
+log "  VRAM (total GPU, informational only): no-cull=${ncv}MiB single=${av}MiB cluster=${VRAM[b_cluster]:-?}MiB sep=${VRAM[c_separated]:-?}MiB"
+log "  note: nvidia-smi reports TOTAL GPU memory (engine+render dominated, ~GB) so the"
+log "        mesh-registration delta is below the noise floor on a small map. The GB-scale"
+log "        VRAM saving appears on large maps where no-cull exhausts OptiX memory;"
+log "        registered mesh count is the reliable proxy (mesh data dominates OptiX VRAM)."
+log "------------------------------------------------------------"
 verdict=0
-a=${CACHED[a_single]:-0}; c=${CACHED[c_separated]:-0}
-sa=${SENSORS[a_single]:-0}; sc=${SENSORS[c_separated]:-0}
 [ "${a:-0}" -gt 0 ] || { log "FAIL: (a) produced no cachedMeshes reading"; verdict=1; }
+if [ "${nc:-0}" -gt "${a:-0}" ]; then log "PASS: culling reduces registered meshes (no-cull=$nc > culled single=$a)"; else log "FAIL: expected no-cull($nc) > culled single($a) — map may fit fully within cull radius (try a larger map)"; verdict=1; fi
 if [ "${sc:-0}" -gt "${sa:-0}" ]; then log "PASS: more sensors registered when separated (c=$sc > a=$sa)"; else log "FAIL: expected sensors(c) > sensors(a), got c=$sc a=$sa"; verdict=1; fi
 if [ "${c:-0}" -gt "${a:-0}" ]; then log "PASS: union registers more geometry for separated sensors (c=$c > a=$a)"; else log "FAIL: expected cachedMeshes(c) > cachedMeshes(a), got c=$c a=$a — if c≈a, increase SEP and re-run"; verdict=1; fi
 [ "$verdict" = 0 ] && log "OVERALL: PASS" || log "OVERALL: FAIL (full server log: $LOG)"

--- a/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLBackendImpl.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLBackendImpl.cpp
@@ -413,6 +413,13 @@ void FRGLBackendImpl::DestroySession(FRGLSessionHandle Handle)
 
     FRGLSession* Session = static_cast<FRGLSession*>(Handle);
 
+    // Remove this sensor from distance-culling registration so its surrounding
+    // geometry can be released. World may already be gone (instance auto-cleaned).
+    if (UWorld* World = Session->World.Get())
+    {
+        FRGLSceneManager::GetInstance(World).UnregisterSensor(static_cast<const void*>(Session));
+    }
+
     // Destroy the entire connected graph via the root node.
     // rgl_graph_destroy destroys all connected nodes in the graph.
     if (Session->UseRaysNode)
@@ -724,8 +731,13 @@ FRGLTickResult FRGLBackendImpl::Tick(
         // Large city maps contain thousands of static meshes; forcing a 300 m minimum
         // can exhaust OptiX memory before the first scan.
         const float RegistrationDistanceCm = FMath::Max(5000.0f, Desc.Range + 2000.0f);
-        SceneMgr.SetSensorPosition(SensorWorldTransform.GetLocation());
-        SceneMgr.SetRegistrationDistance(RegistrationDistanceCm);
+        // SensorId = session handle (stable for the sensor's lifetime). Per-sensor
+        // registration lets spatially separated sensors share one scene via union.
+        SceneMgr.RegisterSensor(
+            static_cast<const void*>(Session),
+            SensorWorldTransform.GetLocation(),
+            RegistrationDistanceCm,
+            SimulationTime);
         SceneMgr.Update(World, SimulationTime);
     }
 

--- a/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLBackendImpl.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLBackendImpl.cpp
@@ -105,7 +105,6 @@ FRGLSessionHandle FRGLBackendImpl::CreateSession(const FRGLSessionConfig& Config
 
     const FLidarDescription& Desc = Config.LidarDesc;
 
-    // Pre-initialize scene manager (triggers world scan)
     if (!World)
     {
         UE_LOG(LogTemp, Error, TEXT("RGLBackendImpl: No world available during session creation"));
@@ -113,8 +112,9 @@ FRGLSessionHandle FRGLBackendImpl::CreateSession(const FRGLSessionConfig& Config
         return nullptr;
     }
 
+    // Do not scan the world here: sensor position is not available yet, and
+    // uploading every static mesh at once can exhaust OptiX GPU memory.
     FRGLSceneManager& SceneMgr = FRGLSceneManager::GetInstance(World);
-    SceneMgr.Update(World);
     rgl_scene_t Scene = SceneMgr.GetScene();
 
     // 1. UseRays node
@@ -719,6 +719,13 @@ FRGLTickResult FRGLBackendImpl::Tick(
     if (World)
     {
         FRGLSceneManager& SceneMgr = FRGLSceneManager::GetInstance(World);
+        const FLidarDescription& Desc = Session->Config.LidarDesc;
+        // Keep the static scene registration close to the actual LiDAR range.
+        // Large city maps contain thousands of static meshes; forcing a 300 m minimum
+        // can exhaust OptiX memory before the first scan.
+        const float RegistrationDistanceCm = FMath::Max(5000.0f, Desc.Range + 2000.0f);
+        SceneMgr.SetSensorPosition(SensorWorldTransform.GetLocation());
+        SceneMgr.SetRegistrationDistance(RegistrationDistanceCm);
         SceneMgr.Update(World, SimulationTime);
     }
 

--- a/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.cpp
@@ -94,6 +94,7 @@ FRGLSceneManager::~FRGLSceneManager()
         }
     }
     MeshCache.Empty();
+    MeshRefCounts.Empty();
 }
 
 FRGLSceneManager& FRGLSceneManager::GetInstance(UWorld* World)
@@ -186,9 +187,13 @@ void FRGLSceneManager::Update(UWorld* World, double SimulationTime)
 void FRGLSceneManager::InitializeFromWorld(UWorld* World)
 {
     RGLLog::Info("RGLSceneManager: Initializing from world...");
+    RGLLog::Info("RGLSceneManager: Static registration radius=",
+                 RegistrationDistanceCm * RGLCoord::UE_TO_RGL, "m",
+                 " sensorValid=", bSensorPositionValid ? "true" : "false");
 
     int32 EntityCount = 0;
     int32 SkippedCount = 0;
+    int32 RangeSkippedCount = 0;
     int32 ActorCount = 0;
     int32 CompCount = 0;
 
@@ -266,16 +271,18 @@ void FRGLSceneManager::InitializeFromWorld(UWorld* World)
 
         for (UStaticMeshComponent* Comp : Components)
         {
-            if (!IsValid(Comp) || !Comp->GetStaticMesh())
+            if (IsValid(Comp) && Comp->GetStaticMesh())
             {
-                continue;
+                ++CompCount;
             }
 
-            ++CompCount;
-
-            // Skip invisible components
-            if (!Comp->IsVisible())
+            bool bOutOfRange = false;
+            if (!ShouldRegisterComponent(Comp, bOutOfRange))
             {
+                if (bOutOfRange)
+                {
+                    ++RangeSkippedCount;
+                }
                 continue;
             }
 
@@ -293,7 +300,8 @@ void FRGLSceneManager::InitializeFromWorld(UWorld* World)
     const int32 MeshCount = MeshCache.Num();
     RGLLog::Info("RGLSceneManager: Scanned", ActorCount, "actors,", CompCount,
                  "mesh components. Uploaded", MeshCount, "unique meshes, created",
-                 EntityCount, "entities (skipped", SkippedCount, ")");
+                 EntityCount, "entities (skipped", SkippedCount,
+                 ", range-skipped", RangeSkippedCount, ")");
 
     const int32 ISMCCompCount = ISMCEntityMap.Num();
     int32 ISMCEntityTotal = 0;
@@ -871,9 +879,151 @@ rgl_mesh_t FRGLSceneManager::UploadMesh(UStaticMesh* StaticMesh)
     return RGLMesh;
 }
 
+void FRGLSceneManager::AddMeshReference(UStaticMesh* StaticMesh, int32 Count)
+{
+    if (!StaticMesh || Count <= 0)
+    {
+        return;
+    }
+
+    int32& RefCount = MeshRefCounts.FindOrAdd(StaticMesh);
+    RefCount += Count;
+}
+
+void FRGLSceneManager::ReleaseMeshReference(UStaticMesh* StaticMesh, int32 Count)
+{
+    if (!StaticMesh || Count <= 0)
+    {
+        return;
+    }
+
+    int32* RefCount = MeshRefCounts.Find(StaticMesh);
+    if (!RefCount)
+    {
+        return;
+    }
+
+    *RefCount -= Count;
+    if (*RefCount > 0)
+    {
+        return;
+    }
+
+    MeshRefCounts.Remove(StaticMesh);
+
+    rgl_mesh_t* RGLMesh = MeshCache.Find(StaticMesh);
+    if (RGLMesh && *RGLMesh)
+    {
+        rgl_mesh_destroy(*RGLMesh);
+    }
+    MeshCache.Remove(StaticMesh);
+}
+
 // ============================================================================
 // Entity management
 // ============================================================================
+
+bool FRGLSceneManager::IsComponentWithinDistance(UStaticMeshComponent* Component, float DistanceCm) const
+{
+    if (!bSensorPositionValid || !IsValid(Component))
+    {
+        return false;
+    }
+
+    const float BoundsRadiusCm = Component->Bounds.SphereRadius;
+    const FVector BoundsCenter = Component->Bounds.Origin;
+    const float EffectiveDistanceCm = DistanceCm + BoundsRadiusCm;
+    return FVector::DistSquared(BoundsCenter, SensorPosition) <= FMath::Square(EffectiveDistanceCm);
+}
+
+bool FRGLSceneManager::IsInstanceWithinDistance(
+    UInstancedStaticMeshComponent* Component,
+    UStaticMesh* StaticMesh,
+    const FTransform& InstanceTransform,
+    float DistanceCm) const
+{
+    if (!bSensorPositionValid || !IsValid(Component) || !StaticMesh)
+    {
+        return false;
+    }
+
+    const FVector Scale = InstanceTransform.GetScale3D();
+    const float MaxScale = FMath::Max(FMath::Max(FMath::Abs(Scale.X), FMath::Abs(Scale.Y)), FMath::Abs(Scale.Z));
+    const float BoundsRadiusCm = StaticMesh->GetBounds().SphereRadius * MaxScale;
+    const float EffectiveDistanceCm = DistanceCm + BoundsRadiusCm;
+    return FVector::DistSquared(InstanceTransform.GetLocation(), SensorPosition) <=
+           FMath::Square(EffectiveDistanceCm);
+}
+
+bool FRGLSceneManager::ShouldRegisterComponent(UStaticMeshComponent* Component, bool& bOutOfRange) const
+{
+    bOutOfRange = false;
+
+    if (!IsValid(Component) || !Component->GetStaticMesh() || !Component->IsVisible())
+    {
+        return false;
+    }
+
+    const FTransform WorldTransform = Component->GetComponentTransform();
+    const FVector Scale = WorldTransform.GetScale3D();
+    if (FMath::IsNearlyZero(Scale.X) || FMath::IsNearlyZero(Scale.Y) || FMath::IsNearlyZero(Scale.Z))
+    {
+        return false;
+    }
+
+    AActor* Owner = Component->GetOwner();
+    const FString OwnerName = Owner ? Owner->GetName() : FString();
+    const FString ComponentName = Component->GetName();
+    const FString MeshName = Component->GetStaticMesh()->GetName();
+
+    // Sky domes are valid static meshes but should never participate in LiDAR ray tracing.
+    if (OwnerName.Contains(TEXT("Sky"), ESearchCase::IgnoreCase) ||
+        ComponentName.Contains(TEXT("Sky"), ESearchCase::IgnoreCase) ||
+        MeshName.Contains(TEXT("Sky"), ESearchCase::IgnoreCase))
+    {
+        return false;
+    }
+
+    // Movable actors are kept even if the sensor position has not been set yet.
+    if (Component->Mobility != EComponentMobility::Static)
+    {
+        return true;
+    }
+
+    // Static geometry on large maps is large enough to exhaust OptiX if uploaded wholesale.
+    // Register only meshes whose bounds intersect the sensor-centered radius.
+    if (!bSensorPositionValid)
+    {
+        bOutOfRange = true;
+        return false;
+    }
+
+    if (!IsComponentWithinDistance(Component, RegistrationDistanceCm))
+    {
+        bOutOfRange = true;
+        return false;
+    }
+
+    return true;
+}
+
+bool FRGLSceneManager::ShouldKeepRegisteredComponent(UStaticMeshComponent* Component) const
+{
+    bool bOutOfRange = false;
+    if (ShouldRegisterComponent(Component, bOutOfRange))
+    {
+        return true;
+    }
+
+    if (!bOutOfRange || !IsValid(Component))
+    {
+        return false;
+    }
+
+    // Keep a wider unload radius than the load radius to prevent repeated
+    // destroy/recreate near the boundary while the ego vehicle moves.
+    return IsComponentWithinDistance(Component, RegistrationDistanceCm + UnregistrationHysteresisCm);
+}
 
 bool FRGLSceneManager::RegisterComponent(UStaticMeshComponent* Component)
 {
@@ -903,11 +1053,13 @@ bool FRGLSceneManager::RegisterComponent(UStaticMeshComponent* Component)
     {
         return false;
     }
+    AddMeshReference(StaticMesh);
 
     rgl_entity_t Entity = nullptr;
     rgl_status_t Status = rgl_entity_create(&Entity, Scene, RGLMesh);
     if (Status != RGL_SUCCESS || !Entity)
     {
+        ReleaseMeshReference(StaticMesh);
         const char* ErrMsg = nullptr;
         rgl_get_last_error_string(&ErrMsg);
         UE_LOG(LogCarlaRGL, Warning,
@@ -942,6 +1094,7 @@ bool FRGLSceneManager::RegisterComponent(UStaticMeshComponent* Component)
     FEntityInfo Info;
     Info.Entity = Entity;
     Info.Component = Component;
+    Info.StaticMesh = StaticMesh;
     Info.bIsStatic = (Component->Mobility == EComponentMobility::Static);
     Info.bTransformInitialized = true;
     Info.LastTransform = WorldTransform;
@@ -963,6 +1116,7 @@ void FRGLSceneManager::UnregisterComponent(UStaticMeshComponent* Component)
         rgl_entity_destroy(Info->Entity);
         Info->Entity = nullptr;
     }
+    ReleaseMeshReference(Info->StaticMesh);
     EntityMap.Remove(Component);
 }
 
@@ -984,19 +1138,23 @@ bool FRGLSceneManager::RegisterISMComponent(UInstancedStaticMeshComponent* Compo
     {
         return false;
     }
+    AddMeshReference(StaticMesh); // Temporary reference until at least one entity owns the mesh.
 
     const int32 NumInstances = Component->GetInstanceCount();
     if (NumInstances <= 0)
     {
+        ReleaseMeshReference(StaticMesh);
         return false;
     }
 
     FISMCEntityGroup Group;
     Group.Component = Component;
+    Group.StaticMesh = StaticMesh;
     Group.OriginalInstanceCount = NumInstances;
     Group.Entities.Reserve(NumInstances);
 
     int32 SuccessCount = 0;
+    int32 RangeSkippedCount = 0;
     for (int32 i = 0; i < NumInstances; ++i)
     {
         FTransform InstanceTransform;
@@ -1009,6 +1167,13 @@ bool FRGLSceneManager::RegisterISMComponent(UInstancedStaticMeshComponent* Compo
         const FVector Scale = InstanceTransform.GetScale3D();
         if (FMath::IsNearlyZero(Scale.X) || FMath::IsNearlyZero(Scale.Y) || FMath::IsNearlyZero(Scale.Z))
         {
+            continue;
+        }
+
+        if (Component->Mobility == EComponentMobility::Static &&
+            !IsInstanceWithinDistance(Component, StaticMesh, InstanceTransform, RegistrationDistanceCm))
+        {
+            ++RangeSkippedCount;
             continue;
         }
 
@@ -1028,15 +1193,20 @@ bool FRGLSceneManager::RegisterISMComponent(UInstancedStaticMeshComponent* Compo
 
     if (SuccessCount == 0)
     {
+        ReleaseMeshReference(StaticMesh);
         return false;
     }
 
+    Group.MeshRefCount = SuccessCount;
     ISMCEntityMap.Add(Component, MoveTemp(Group));
+    AddMeshReference(StaticMesh, SuccessCount);
+    ReleaseMeshReference(StaticMesh); // Drop the temporary upload reference.
 
     RGLLog::Info("RGLSceneManager: Registered ISMC '",
                  TCHAR_TO_UTF8(*Component->GetName()),
                  "' instances=", NumInstances,
                  " entities=", SuccessCount,
+                 " range-skipped=", RangeSkippedCount,
                  " mesh='", TCHAR_TO_UTF8(*StaticMesh->GetName()), "'");
 
     return true;
@@ -1057,6 +1227,7 @@ void FRGLSceneManager::UnregisterISMComponent(UInstancedStaticMeshComponent* Com
             rgl_entity_destroy(Entity);
         }
     }
+    ReleaseMeshReference(Group->StaticMesh, Group->MeshRefCount);
     ISMCEntityMap.Remove(Component);
 }
 
@@ -1128,6 +1299,11 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
 {
     TSet<UStaticMeshComponent*> CurrentComponents;
     TSet<UInstancedStaticMeshComponent*> CurrentISMComponents;
+    int32 AddedRegular = 0;
+    int32 AddedISM = 0;
+    int32 RemovedRegular = 0;
+    int32 RemovedISM = 0;
+    int32 RangeSkipped = 0;
 
     for (TActorIterator<AActor> It(World); It; ++It)
     {
@@ -1142,8 +1318,13 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
 
         for (UStaticMeshComponent* Comp : Components)
         {
-            if (!IsValid(Comp) || !Comp->GetStaticMesh() || !Comp->IsVisible())
+            bool bOutOfRange = false;
+            if (!ShouldRegisterComponent(Comp, bOutOfRange))
             {
+                if (bOutOfRange)
+                {
+                    ++RangeSkipped;
+                }
                 continue;
             }
 
@@ -1153,7 +1334,10 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
                 CurrentISMComponents.Add(ISMComp);
                 if (!ISMCEntityMap.Contains(ISMComp))
                 {
-                    RegisterISMComponent(ISMComp);
+                    if (RegisterISMComponent(ISMComp))
+                    {
+                        ++AddedISM;
+                    }
                 }
             }
             else
@@ -1161,17 +1345,21 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
                 CurrentComponents.Add(Comp);
                 if (!EntityMap.Contains(Comp))
                 {
-                    RegisterComponent(Comp);
+                    if (RegisterComponent(Comp))
+                    {
+                        ++AddedRegular;
+                    }
                 }
             }
         }
     }
 
-    // Remove regular entities for components that no longer exist
+    // Remove regular entities for components that no longer exist or moved out
+    // of the LiDAR-relevant window.
     TArray<UStaticMeshComponent*> ToRemove;
     for (auto& Pair : EntityMap)
     {
-        if (!CurrentComponents.Contains(Pair.Key))
+        if (!CurrentComponents.Contains(Pair.Key) && !ShouldKeepRegisteredComponent(Pair.Key))
         {
             ToRemove.Add(Pair.Key);
         }
@@ -1179,13 +1367,15 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
     for (UStaticMeshComponent* Comp : ToRemove)
     {
         UnregisterComponent(Comp);
+        ++RemovedRegular;
     }
 
-    // Remove ISMC entities for components that no longer exist
+    // Remove ISMC entities for components that no longer exist or moved out
+    // of the LiDAR-relevant window.
     TArray<UInstancedStaticMeshComponent*> ISMCToRemove;
     for (auto& Pair : ISMCEntityMap)
     {
-        if (!CurrentISMComponents.Contains(Pair.Key))
+        if (!CurrentISMComponents.Contains(Pair.Key) && !ShouldKeepRegisteredComponent(Pair.Key))
         {
             ISMCToRemove.Add(Pair.Key);
         }
@@ -1193,6 +1383,18 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
     for (UInstancedStaticMeshComponent* Comp : ISMCToRemove)
     {
         UnregisterISMComponent(Comp);
+        ++RemovedISM;
+    }
+
+    if (AddedRegular || AddedISM || RemovedRegular || RemovedISM)
+    {
+        RGLLog::Info("RGLSceneManager: Dynamic sync active regular=", EntityMap.Num(),
+                     " ISMC=", ISMCEntityMap.Num(),
+                     " cachedMeshes=", MeshCache.Num(),
+                     " added=", AddedRegular, "+", AddedISM,
+                     " removed=", RemovedRegular, "+", RemovedISM,
+                     " range-skipped=", RangeSkipped,
+                     " radius(m)=", RegistrationDistanceCm * RGLCoord::UE_TO_RGL);
     }
 }
 

--- a/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.cpp
@@ -1406,6 +1406,15 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
     TArray<UStaticMeshComponent*> ToRemove;
     for (auto& Pair : EntityMap)
     {
+        // A destroyed component leaves a dangling raw key in this non-UObject map
+        // (GC does not null it: e.g. LargeMap tile stream-out, actor destruction).
+        // Detect it via the weak pointer and remove without dereferencing the raw
+        // key through ShouldKeepRegisteredComponent. Mirrors UpdateTransforms's guard.
+        if (!Pair.Value.Component.IsValid())
+        {
+            ToRemove.Add(Pair.Key);
+            continue;
+        }
         if (!CurrentComponents.Contains(Pair.Key) && !ShouldKeepRegisteredComponent(Pair.Key))
         {
             ToRemove.Add(Pair.Key);
@@ -1422,6 +1431,12 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
     TArray<UInstancedStaticMeshComponent*> ISMCToRemove;
     for (auto& Pair : ISMCEntityMap)
     {
+        // Same dangling-raw-key guard as the regular-entity loop above.
+        if (!Pair.Value.Component.IsValid())
+        {
+            ISMCToRemove.Add(Pair.Key);
+            continue;
+        }
         if (!CurrentISMComponents.Contains(Pair.Key) && !ShouldKeepRegisteredComponent(Pair.Key))
         {
             ISMCToRemove.Add(Pair.Key);

--- a/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.cpp
+++ b/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.cpp
@@ -161,12 +161,36 @@ void FRGLSceneManager::Update(UWorld* World, double SimulationTime)
         bInitialized = true;
     }
 
-    // Periodic full scan for new/removed actors (time-based)
+    // Track sim time for stale-sensor eviction (used inside SyncWorldComponents).
+    CurrentSimTime = (SimulationTime >= 0.0) ? SimulationTime : World->GetTimeSeconds();
+
+    // Sync on a time interval OR when any sensor has moved far enough that newly
+    // relevant geometry could be missed before the next periodic sync
+    // (Phase 1: high-speed safety).
     TimeSinceLastSync += World->GetDeltaSeconds();
-    if (TimeSinceLastSync >= SyncIntervalSeconds)
+    bool bShouldSync = (TimeSinceLastSync >= SyncIntervalSeconds);
+    if (!bShouldSync)
+    {
+        for (const auto& Pair : RegisteredSensors)
+        {
+            const FSensorRegistration& S = Pair.Value;
+            const float TriggerCm = 0.2f * S.RegistrationDistanceCm;
+            if (!S.bLastSyncValid || FVector::Dist(S.Position, S.LastSyncPosition) > TriggerCm)
+            {
+                bShouldSync = true;
+                break;
+            }
+        }
+    }
+    if (bShouldSync)
     {
         SyncWorldComponents(World);
         TimeSinceLastSync = 0.0f;
+        for (auto& Pair : RegisteredSensors)
+        {
+            Pair.Value.LastSyncPosition = Pair.Value.Position;
+            Pair.Value.bLastSyncValid = true;
+        }
     }
 
     // Update scene time for velocity computation and ROS2 timestamp synchronization.
@@ -187,9 +211,8 @@ void FRGLSceneManager::Update(UWorld* World, double SimulationTime)
 void FRGLSceneManager::InitializeFromWorld(UWorld* World)
 {
     RGLLog::Info("RGLSceneManager: Initializing from world...");
-    RGLLog::Info("RGLSceneManager: Static registration radius=",
-                 RegistrationDistanceCm * RGLCoord::UE_TO_RGL, "m",
-                 " sensorValid=", bSensorPositionValid ? "true" : "false");
+    RGLLog::Info("RGLSceneManager: Initializing with registered sensors=",
+                 RegisteredSensors.Num());
 
     int32 EntityCount = 0;
     int32 SkippedCount = 0;
@@ -923,36 +946,43 @@ void FRGLSceneManager::ReleaseMeshReference(UStaticMesh* StaticMesh, int32 Count
 // Entity management
 // ============================================================================
 
-bool FRGLSceneManager::IsComponentWithinDistance(UStaticMeshComponent* Component, float DistanceCm) const
+bool FRGLSceneManager::IsWithinAnySensor(const FVector& CenterCm, float BoundsRadiusCm, float ExtraCm) const
 {
-    if (!bSensorPositionValid || !IsValid(Component))
+    for (const auto& Pair : RegisteredSensors)
+    {
+        const FSensorRegistration& S = Pair.Value;
+        const float EffectiveDistanceCm = S.RegistrationDistanceCm + BoundsRadiusCm + ExtraCm;
+        if (FVector::DistSquared(CenterCm, S.Position) <= FMath::Square(EffectiveDistanceCm))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool FRGLSceneManager::IsComponentWithinAnySensor(UStaticMeshComponent* Component, float ExtraCm) const
+{
+    if (!IsValid(Component))
     {
         return false;
     }
-
-    const float BoundsRadiusCm = Component->Bounds.SphereRadius;
-    const FVector BoundsCenter = Component->Bounds.Origin;
-    const float EffectiveDistanceCm = DistanceCm + BoundsRadiusCm;
-    return FVector::DistSquared(BoundsCenter, SensorPosition) <= FMath::Square(EffectiveDistanceCm);
+    return IsWithinAnySensor(Component->Bounds.Origin, Component->Bounds.SphereRadius, ExtraCm);
 }
 
-bool FRGLSceneManager::IsInstanceWithinDistance(
+bool FRGLSceneManager::IsInstanceWithinAnySensor(
     UInstancedStaticMeshComponent* Component,
     UStaticMesh* StaticMesh,
     const FTransform& InstanceTransform,
-    float DistanceCm) const
+    float ExtraCm) const
 {
-    if (!bSensorPositionValid || !IsValid(Component) || !StaticMesh)
+    if (!IsValid(Component) || !StaticMesh)
     {
         return false;
     }
-
     const FVector Scale = InstanceTransform.GetScale3D();
     const float MaxScale = FMath::Max(FMath::Max(FMath::Abs(Scale.X), FMath::Abs(Scale.Y)), FMath::Abs(Scale.Z));
     const float BoundsRadiusCm = StaticMesh->GetBounds().SphereRadius * MaxScale;
-    const float EffectiveDistanceCm = DistanceCm + BoundsRadiusCm;
-    return FVector::DistSquared(InstanceTransform.GetLocation(), SensorPosition) <=
-           FMath::Square(EffectiveDistanceCm);
+    return IsWithinAnySensor(InstanceTransform.GetLocation(), BoundsRadiusCm, ExtraCm);
 }
 
 bool FRGLSceneManager::ShouldRegisterComponent(UStaticMeshComponent* Component, bool& bOutOfRange) const
@@ -984,21 +1014,21 @@ bool FRGLSceneManager::ShouldRegisterComponent(UStaticMeshComponent* Component, 
         return false;
     }
 
-    // Movable actors are kept even if the sensor position has not been set yet.
+    // Movable actors are kept even if no sensor has registered yet.
     if (Component->Mobility != EComponentMobility::Static)
     {
         return true;
     }
 
     // Static geometry on large maps is large enough to exhaust OptiX if uploaded wholesale.
-    // Register only meshes whose bounds intersect the sensor-centered radius.
-    if (!bSensorPositionValid)
+    // Register only meshes whose bounds intersect the union of all sensor spheres.
+    if (RegisteredSensors.Num() == 0)
     {
         bOutOfRange = true;
         return false;
     }
 
-    if (!IsComponentWithinDistance(Component, RegistrationDistanceCm))
+    if (!IsComponentWithinAnySensor(Component, 0.0f))
     {
         bOutOfRange = true;
         return false;
@@ -1021,8 +1051,8 @@ bool FRGLSceneManager::ShouldKeepRegisteredComponent(UStaticMeshComponent* Compo
     }
 
     // Keep a wider unload radius than the load radius to prevent repeated
-    // destroy/recreate near the boundary while the ego vehicle moves.
-    return IsComponentWithinDistance(Component, RegistrationDistanceCm + UnregistrationHysteresisCm);
+    // destroy/recreate near the boundary while sensors move.
+    return IsComponentWithinAnySensor(Component, UnregistrationHysteresisCm);
 }
 
 bool FRGLSceneManager::RegisterComponent(UStaticMeshComponent* Component)
@@ -1171,7 +1201,7 @@ bool FRGLSceneManager::RegisterISMComponent(UInstancedStaticMeshComponent* Compo
         }
 
         if (Component->Mobility == EComponentMobility::Static &&
-            !IsInstanceWithinDistance(Component, StaticMesh, InstanceTransform, RegistrationDistanceCm))
+            !IsInstanceWithinAnySensor(Component, StaticMesh, InstanceTransform, 0.0f))
         {
             ++RangeSkippedCount;
             continue;
@@ -1297,6 +1327,23 @@ void FRGLSceneManager::UpdateTransforms()
 
 void FRGLSceneManager::SyncWorldComponents(UWorld* World)
 {
+    // Evict sensors that stopped refreshing (paused but not destroyed) so their
+    // surrounding geometry can be released and stop holding VRAM.
+    {
+        TArray<const void*> StaleSensors;
+        for (const auto& Pair : RegisteredSensors)
+        {
+            if (CurrentSimTime - Pair.Value.LastUpdateTime > SensorStaleTimeoutSeconds)
+            {
+                StaleSensors.Add(Pair.Key);
+            }
+        }
+        for (const void* Id : StaleSensors)
+        {
+            RegisteredSensors.Remove(Id);
+        }
+    }
+
     TSet<UStaticMeshComponent*> CurrentComponents;
     TSet<UInstancedStaticMeshComponent*> CurrentISMComponents;
     int32 AddedRegular = 0;
@@ -1388,13 +1435,13 @@ void FRGLSceneManager::SyncWorldComponents(UWorld* World)
 
     if (AddedRegular || AddedISM || RemovedRegular || RemovedISM)
     {
-        RGLLog::Info("RGLSceneManager: Dynamic sync active regular=", EntityMap.Num(),
+        RGLLog::Info("RGLSceneManager: Dynamic sync active sensors=", RegisteredSensors.Num(),
+                     " regular=", EntityMap.Num(),
                      " ISMC=", ISMCEntityMap.Num(),
                      " cachedMeshes=", MeshCache.Num(),
                      " added=", AddedRegular, "+", AddedISM,
                      " removed=", RemovedRegular, "+", RemovedISM,
-                     " range-skipped=", RangeSkipped,
-                     " radius(m)=", RegistrationDistanceCm * RGLCoord::UE_TO_RGL);
+                     " range-skipped=", RangeSkipped);
     }
 }
 

--- a/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.h
+++ b/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.h
@@ -59,7 +59,21 @@ public:
     void UpdateGroundPlane(UWorld* World, const FTransform& SensorTransform);
 
     /// Set sensor position for distance culling. Call before Update().
-    void SetSensorPosition(const FVector& Position) { SensorPosition = Position; }
+    void SetSensorPosition(const FVector& Position)
+    {
+        SensorPosition = Position;
+        bSensorPositionValid = true;
+    }
+
+    /// Set static mesh registration radius around the sensor (UE5 cm).
+    void SetRegistrationDistance(float DistanceCm)
+    {
+        const float ClampedDistanceCm = FMath::Max(5000.0f, DistanceCm);
+        RegistrationDistanceCm = bRegistrationDistanceConfigured
+            ? FMath::Max(RegistrationDistanceCm, ClampedDistanceCm)
+            : ClampedDistanceCm;
+        bRegistrationDistanceConfigured = true;
+    }
 
     /// Set the world sync interval in simulation seconds. Default: 1.0s. Minimum: 0.1s.
     void SetSyncInterval(float Seconds) { SyncIntervalSeconds = FMath::Max(0.1f, Seconds); }
@@ -84,6 +98,20 @@ private:
     /// Create an RGL entity for a static mesh component. Returns true on success.
     bool RegisterComponent(UStaticMeshComponent* Component);
 
+    /// Filter components before uploading them to RGL.
+    bool ShouldRegisterComponent(UStaticMeshComponent* Component, bool& bOutOfRange) const;
+
+    /// Check whether an already registered component should stay in the active RGL scene.
+    bool ShouldKeepRegisteredComponent(UStaticMeshComponent* Component) const;
+
+    /// Component/instance distance culling helpers.
+    bool IsComponentWithinDistance(UStaticMeshComponent* Component, float DistanceCm) const;
+    bool IsInstanceWithinDistance(
+        UInstancedStaticMeshComponent* Component,
+        UStaticMesh* StaticMesh,
+        const FTransform& InstanceTransform,
+        float DistanceCm) const;
+
     /// Remove an RGL entity for a destroyed component.
     void UnregisterComponent(UStaticMeshComponent* Component);
 
@@ -92,6 +120,10 @@ private:
 
     /// Remove all RGL entities for an ISMC.
     void UnregisterISMComponent(UInstancedStaticMeshComponent* Component);
+
+    /// Track active RGL entity references to cached meshes and free unused GPU meshes.
+    void AddMeshReference(UStaticMesh* StaticMesh, int32 Count = 1);
+    void ReleaseMeshReference(UStaticMesh* StaticMesh, int32 Count = 1);
 
     /// Update all entity transforms to match current UE5 state.
     void UpdateTransforms();
@@ -111,11 +143,15 @@ private:
     /// Uses TMap for UE5 compatibility and safe iteration.
     TMap<UStaticMesh*, rgl_mesh_t> MeshCache;
 
+    /// Active entity references per cached mesh. Meshes are released when this reaches zero.
+    TMap<UStaticMesh*, int32> MeshRefCounts;
+
     /// Mapping: UStaticMeshComponent* -> RGL entity + weak reference.
     struct FEntityInfo
     {
         rgl_entity_t Entity = nullptr;
         TWeakObjectPtr<UStaticMeshComponent> Component;
+        UStaticMesh* StaticMesh = nullptr;     // Mesh referenced by Entity; used for cache ref-counting.
         bool bIsStatic = false;            // True if Mobility == Static (never moves)
         bool bTransformInitialized = false; // True after first transform set
         bool bInRange = true;              // Distance culling state
@@ -128,7 +164,9 @@ private:
     {
         TArray<rgl_entity_t> Entities;
         TWeakObjectPtr<UInstancedStaticMeshComponent> Component;
+        UStaticMesh* StaticMesh = nullptr; // Mesh referenced by Entities; used for cache ref-counting.
         int32 OriginalInstanceCount = 0;  // Instance count at registration time (may differ from Entities.Num() due to skipped instances)
+        int32 MeshRefCount = 0;           // Number of live RGL entities referencing StaticMesh.
     };
     TMap<UInstancedStaticMeshComponent*, FISMCEntityGroup> ISMCEntityMap;
 
@@ -139,9 +177,14 @@ private:
 
     /// Sensor position for distance culling (UE5 cm)
     FVector SensorPosition = FVector::ZeroVector;
+    bool bSensorPositionValid = false;
 
-    /// Distance culling: entities beyond this distance are deactivated in RGL (cm)
-    static constexpr float CULL_DISTANCE_CM = 15000.0f; // 150m
+    /// Static mesh registration radius around the sensor (UE5 cm).
+    float RegistrationDistanceCm = 30000.0f; // 300m default, expanded from LiDAR range by backend
+    bool bRegistrationDistanceConfigured = false;
+
+    /// Hysteresis for dynamic unloads to avoid add/remove churn around the boundary (UE5 cm).
+    float UnregistrationHysteresisCm = 2000.0f; // 20m
 
     /// Virtual ground plane (not tied to any UE5 component).
     rgl_mesh_t GroundMesh = nullptr;

--- a/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.h
+++ b/Unreal/CarlaUnreal/Plugins/CarlaRGL/Source/CarlaRGL/RGLSceneManager.h
@@ -58,21 +58,21 @@ public:
     /// Uses a UE5 line trace to detect actual ground level.
     void UpdateGroundPlane(UWorld* World, const FTransform& SensorTransform);
 
-    /// Set sensor position for distance culling. Call before Update().
-    void SetSensorPosition(const FVector& Position)
+    /// Register or refresh a sensor's culling sphere. Call each tick before Update().
+    /// SensorId must be stable for the sensor's lifetime (use the session handle).
+    /// Now = current simulation time (seconds), used for stale-sensor eviction.
+    void RegisterSensor(const void* SensorId, const FVector& Position, float DistanceCm, double Now)
     {
-        SensorPosition = Position;
-        bSensorPositionValid = true;
+        FSensorRegistration& S = RegisteredSensors.FindOrAdd(SensorId);
+        S.Position = Position;
+        S.RegistrationDistanceCm = FMath::Max(5000.0f, DistanceCm);
+        S.LastUpdateTime = Now;
     }
 
-    /// Set static mesh registration radius around the sensor (UE5 cm).
-    void SetRegistrationDistance(float DistanceCm)
+    /// Remove a sensor when its session is destroyed.
+    void UnregisterSensor(const void* SensorId)
     {
-        const float ClampedDistanceCm = FMath::Max(5000.0f, DistanceCm);
-        RegistrationDistanceCm = bRegistrationDistanceConfigured
-            ? FMath::Max(RegistrationDistanceCm, ClampedDistanceCm)
-            : ClampedDistanceCm;
-        bRegistrationDistanceConfigured = true;
+        RegisteredSensors.Remove(SensorId);
     }
 
     /// Set the world sync interval in simulation seconds. Default: 1.0s. Minimum: 0.1s.
@@ -104,13 +104,14 @@ private:
     /// Check whether an already registered component should stay in the active RGL scene.
     bool ShouldKeepRegisteredComponent(UStaticMeshComponent* Component) const;
 
-    /// Component/instance distance culling helpers.
-    bool IsComponentWithinDistance(UStaticMeshComponent* Component, float DistanceCm) const;
-    bool IsInstanceWithinDistance(
+    /// Union distance culling helpers (within ANY registered sensor's sphere).
+    bool IsWithinAnySensor(const FVector& CenterCm, float BoundsRadiusCm, float ExtraCm) const;
+    bool IsComponentWithinAnySensor(UStaticMeshComponent* Component, float ExtraCm) const;
+    bool IsInstanceWithinAnySensor(
         UInstancedStaticMeshComponent* Component,
         UStaticMesh* StaticMesh,
         const FTransform& InstanceTransform,
-        float DistanceCm) const;
+        float ExtraCm) const;
 
     /// Remove an RGL entity for a destroyed component.
     void UnregisterComponent(UStaticMeshComponent* Component);
@@ -175,16 +176,28 @@ private:
     /// Frame tracking — skip Update if already done this frame
     uint64 LastUpdateFrame = 0;
 
-    /// Sensor position for distance culling (UE5 cm)
-    FVector SensorPosition = FVector::ZeroVector;
-    bool bSensorPositionValid = false;
-
-    /// Static mesh registration radius around the sensor (UE5 cm).
-    float RegistrationDistanceCm = 30000.0f; // 300m default, expanded from LiDAR range by backend
-    bool bRegistrationDistanceConfigured = false;
+    /// Per-sensor culling registration. A static mesh is registered if it falls
+    /// within ANY active sensor's sphere (union), so spatially separated sensors
+    /// (multi-vehicle / roadside) are all served correctly by the single shared scene.
+    struct FSensorRegistration
+    {
+        FVector Position = FVector::ZeroVector;
+        float   RegistrationDistanceCm = 30000.0f; // per-sensor radius (UE5 cm)
+        FVector LastSyncPosition = FVector::ZeroVector;
+        bool    bLastSyncValid = false;
+        double  LastUpdateTime = 0.0;              // sim time of last RegisterSensor()
+    };
+    /// Key = sensor id (session handle). Pointer key uses pointer hashing.
+    TMap<const void*, FSensorRegistration> RegisteredSensors;
 
     /// Hysteresis for dynamic unloads to avoid add/remove churn around the boundary (UE5 cm).
     float UnregistrationHysteresisCm = 2000.0f; // 20m
+
+    /// Evict sensors that stopped ticking (paused but not destroyed) to free their VRAM.
+    float SensorStaleTimeoutSeconds = 5.0f;
+
+    /// Latest simulation time seen by Update(); used for stale-sensor eviction.
+    double CurrentSimTime = 0.0;
 
     /// Virtual ground plane (not tied to any UE5 component).
     rgl_mesh_t GroundMesh = nullptr;


### PR DESCRIPTION
## Summary
Distance-based dynamic scene registration for the RGL LiDAR backend, with multi-sensor support:
- Register only static meshes within the union of per-sensor radii; free out-of-range GPU meshes via reference counting → bounds OptiX VRAM on large maps.
- Per-sensor registry + union test so spatially separated sensors are all served (replaces the single-sensor, first-tick-wins behavior).
- Phase-1 distance-based sync trigger (high-speed safety), stale-sensor TTL eviction, observability logging.
- Robustness fix: guard scene-sync removal against destroyed component map keys (a SIGSEGV on streaming large maps).
- Automated regression test (`PythonAPI/rgl/tests/test_multisensor_culling.sh`).

The VRAM-reduction core is authored by Taiga Takano (commit preserved).

## Test Plan
- [ ] Automated test: single / co-located cluster / spatially-separated sensor configs
- [ ] Verified: culling registers only a small fraction of in-range meshes on large maps; multi-sensor union registers every sensor's neighborhood

## Notes
- Stacked on #57 (enum build fix); base retargets to `main` after #57 merges.