### PR TITLE
fix(largemap): rebase world origin to editor viewport camera outside PIE

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.cpp
@@ -16,6 +16,10 @@
 
 #include <util/ue-header-guard-begin.h>
 #include "Engine/WorldComposition.h"
+#if WITH_EDITOR
+#include "EditorViewportClient.h"
+#include "Editor.h"
+#endif
 #include "Engine/ObjectLibrary.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
@@ -922,6 +926,29 @@ void ALargeMapManager::ConvertDormantToActiveActors()
 void ALargeMapManager::CheckIfRebaseIsNeeded()
 {
   TRACE_CPUPROFILER_EVENT_SCOPE(ALargeMapManager::CheckIfRebaseIsNeeded);
+
+#if WITH_EDITOR
+  // In editor mode (not PIE), rebase based on the editor viewport camera position
+  // because ActorsToConsider contains no hero actors when no game is running.
+  if (GEditor && !GEditor->IsPlayingSessionInEditor())
+  {
+    UWorld* World = GetWorld();
+    for (FEditorViewportClient* VC : GEditor->GetAllViewportClients())
+    {
+      if (!VC || !VC->IsLevelEditorClient()) continue;
+      FVector CameraLocation = VC->GetViewLocation();
+      if (CameraLocation.SizeSquared() > RebaseOriginDistanceSquared)
+      {
+        TileID TileId = GetTileID(CurrentOriginD + FDVector(CameraLocation));
+        FVector NewOrigin = GetTileLocation(TileId);
+        World->SetNewWorldOrigin(FIntVector(NewOrigin));
+        break;
+      }
+    }
+    return;
+  }
+#endif
+
   if(ActorsToConsider.Num() > 0)
   {
     UWorld* World = GetWorld();

--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.h
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/MapGen/LargeMapManager.h
@@ -92,6 +92,7 @@ public:
 
   // Called every frame
   void Tick(float DeltaTime) override;
+  virtual bool ShouldTickIfViewportsOnly() const override { return true; }
 
   UFUNCTION(BlueprintCallable, Category = "Large Map Manager")
   void GenerateMap(FString InAssetsPath);


### PR DESCRIPTION
## What
Editor-only fix for the large-map origin rebase.

In non-PIE editor sessions `ActorsToConsider` holds no hero actor, so the world
origin never rebases as the camera moves far from the origin — distant tiles
then suffer floating-point precision loss (jitter). This drives the rebase from
the active level-editor viewport camera when no play session is running, and
lets the manager tick in viewport-only mode.

## Changes
- `LargeMapManager.cpp`: when `GEditor` is in editor mode (not PIE), pick the
  active level-editor viewport camera and rebase the world origin from it.
- `LargeMapManager.h`: `ShouldTickIfViewportsOnly() -> true` so the rebase runs
  in the editor viewport.

## Notes
- PIE / packaged runtime behaviour is unchanged (guarded by `WITH_EDITOR` +
  `!IsPlayingSessionInEditor()`).
- Authored by Taiga Takano (origin of the fix); committed via port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)