### PR TITLE
fix(traffic): guard against null UTrafficLightComponent in controller cycle

### DIFF
--- a/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightController.cpp
+++ b/Unreal/CarlaUnreal/Plugins/Carla/Source/Carla/Traffic/TrafficLightController.cpp
@@ -102,13 +102,23 @@ bool UTrafficLightController::IsCycleFinished() const
 void UTrafficLightController::SetTrafficLightsState(ETrafficLightState NewState)
 {
   SetCurrentLightState(NewState);
+  // Guard against stale/null entries: dynamically-built groups can hold
+  // references to components whose actors were destroyed (the UPROPERTY array
+  // is then nulled by GC). Mirrors the null-check in
+  // UTrafficLightComponent::SetLightState's Vehicles loop.
   for(auto *Light : TrafficLights)
   {
-    Light->SetLightState(NewState);
+    if (Light != nullptr)
+    {
+      Light->SetLightState(NewState);
+    }
   }
   for(FCarlaActor* Light : TrafficLightCarlaActors)
   {
-    Light->SetTrafficLightState(NewState);
+    if (Light != nullptr)
+    {
+      Light->SetTrafficLightState(NewState);
+    }
   }
 }
 


### PR DESCRIPTION
## What
Null-guard for the traffic-light controller cycle to fix a SIGSEGV.

`UTrafficLightController::SetTrafficLightsState` dereferenced every entry of
`TrafficLights` / `TrafficLightCarlaActors` without a null check. Dynamically
built traffic-light groups can hold references to components whose actors were
destroyed (the UPROPERTY array is then nulled by GC); the group auto-cycle
(`ATrafficLightGroup::Tick -> NextState`) then crashed.

## Fix
Mirror the existing null-check already used in
`UTrafficLightComponent::SetLightState`'s Vehicles loop — skip null entries.

## Notes
- Pure robustness guard, no behaviour change for valid components.
- 1 file, +12/-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)